### PR TITLE
contact.html: fix freenode address & use KiwiIRC

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,6 @@ title: Contact
 layout: default
 ---
       <div class="alert alert-info">
-        <strong>Have your own IRC client?</strong> You can chat with us on <a href="irc://irc.freenode.net/ircv3"><strong>irc.freenode.net</strong></a> in <a href="irc://irc.freenode.net/ircv3"><strong>#ircv3</strong></a>.
+        <strong>Have your own IRC client?</strong> You can chat with us on <a href="ircs://irc.freenode.net:6697/#ircv3"><strong>irc.freenode.net</strong></a> in <a href="ircs://irc.freenode.net:6697/#ircv3"><strong>#ircv3</strong></a>.
       </div>
-      <iframe src="https://webchat.freenode.net?channels=%23ircv3&uio=MTE9MTc0b3" width="100%" height="467"></iframe>
+      <iframe src="https://kiwiirc.com/client/irc.freenode.net:+6697/#ircv3" style="border:0; width:100%; height:467px;"></iframe>


### PR DESCRIPTION
I believe the previous format wasn't correct as it was missing the port
number and channel prefix. Missing SSL while it will be encouraged (STS)
also appears weird.

I replaced QWebIRC with Kiwi, because it doesn't support IRCv3 while
Kiwi does and Kiwi is also part of stakeholders.