### PR TITLE
Update capabilities support of Limnoria

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -313,6 +313,11 @@
           - metadata
           - monitor
           - account-tag
+          - cap-notify: "CAP ADD is ignored"
+          - chghost
+          - invite-notify
+          - server-time
+          - userhost-in-names
     - name: Willie
       link: http://willie.dftba.net
       support:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -313,11 +313,13 @@
           - metadata
           - monitor
           - account-tag
-          - cap-notify: "CAP ADD is ignored"
           - chghost
           - invite-notify
           - server-time
           - userhost-in-names
+      partial:
+        v3.2:
+          cap-notify: "CAP NEW is ignored"
     - name: Willie
       link: http://willie.dftba.net
       support:


### PR DESCRIPTION
These capabilities were added in the last release.
`cap-notify` is partially supported: `CAP DEL` is properly handled, and `CAP ADD` is ignored