### PR TITLE
note the support of account-tag support from IRCv3.2 in Colloquy

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -20,6 +20,7 @@
         v3.2:
           - cap
           - self-message
+          - account-tag
           - cap-notify
           - chghost
           - echo-message
@@ -219,6 +220,7 @@
         v3.2:
           - cap
           - self-message
+          - account-tag
           - cap-notify
           - chghost
           - echo-message


### PR DESCRIPTION
Finalized account-tag support was added to Colloquy's underlying library a few weeks ago, and has shipped in both Mobile Colloquy for iOS, and Colloquy beta's for Mac OS X.