### PR TITLE
Fix/clarify IRCCloud server support

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -299,18 +299,6 @@
           echo-message: "Git, client→ZNC only"
           batch: "1.6.0+ as <code>znc.in/batch</code>, Git as <code>batch</code>, client→ZNC only"
           server-time: "1.2+ as <code>znc.in/server-time-iso</code>, Git as <code>server-time</code>, client→ZNC only"
-    - name: IRCCloud
-      link: https://www.irccloud.com
-      support:
-        v3.1:
-          - cap
-          - multi-prefix
-          - account-notify
-          - away-notify
-          - extended-join
-          - sasl
-        v3.2:
-          - userhost-in-names
 
 - name: Bots
   software:

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -23,8 +23,8 @@
           account-notify: 6.5 +
           extended-join: 6.5 +
           away-notify: 6.5 +
-    - name: IRCCloud
-      link: https://www.irccloud.com
+    - name: IRCCloud Teams
+      link: https://blog.irccloud.com/private-teams-servers/
       support:
         v3.1:
           - cap

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -28,10 +28,16 @@
       support:
         v3.1:
           - cap
-          - multi-prefix
           - away-notify
           - extended-join
+          - multi-prefix
+        v3.2:
           - userhost-in-names
+      na:
+        v3.1:
+          account-notify: PASS login, no logout
+          sasl: PASS auth only
+          tls: secure only
     - name: InspIRCd
       link: http://www.inspircd.org
       support:

--- a/_includes/software_list.html
+++ b/_includes/software_list.html
@@ -33,7 +33,7 @@
             </td>
             {% for ext in irc_ver[1].specs %}
             {% capture ext_name %}{{ ext[0] }}{% endcapture %}
-            <td colgroup="2" class="support {% if sw.support[irc_verkey] contains ext_name %}supported{% elsif sw.partial[irc_verkey] contains ext_name %}partial{% else %}unsupported{% endif %}">
+            <td colgroup="2" class="support {% if sw.support[irc_verkey] contains ext_name %}supported{% elsif sw.partial[irc_verkey] contains ext_name %}partial{% elsif sw.na[irc_verkey] contains ext_name %}na{% else %}unsupported{% endif %}">
                 {% if sw.support[irc_verkey] contains ext_name %}
                     {% assign capab = sw.support[irc_verkey][ext_name] %}
                     {% assign default = 'Yes' %}
@@ -41,6 +41,10 @@
                 {% elsif sw.partial[irc_verkey] contains ext_name %}
                     {% assign capab = sw.partial[irc_verkey][ext_name] %}
                     {% assign default = 'Partial' %}
+                    {% include show_capability.html %}
+                {% elsif sw.na[irc_verkey] contains ext_name %}
+                    {% assign capab = sw.na[irc_verkey][ext_name] %}
+                    {% assign default = 'Not applicable' %}
                     {% include show_capability.html %}
                 {% else %}
                     No

--- a/css/ircv3-style.css
+++ b/css/ircv3-style.css
@@ -114,6 +114,10 @@ a.irc-extension {
   background-color: #eeeeaa;
   color: #303010;
 }
+.sw-table .na {
+  background-color: #ddd;
+  color: #101010;
+}
 .sw-table .unsupported {
   background-color: #eeaaa7;
   color: #30100E;


### PR DESCRIPTION
* The server requires TLS and PASS for auth, so sasl, tls, account-notify caps are N/A. 
* Fixed userhost-in-names in 3.2 section.