### PR TITLE
software: Separate and highlight the required cap columns

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -5,6 +5,17 @@ v3.1:
       name: CAP
       description: Capability Negotiation
       link: http://ircv3.net/specs/core/capability-negotiation-3.1.html
+      required: true
+    sasl:
+      name: sasl
+      description: SASL
+      link: http://ircv3.net/specs/extensions/sasl-3.1.html
+      required: true
+    multi-prefix:
+      name: multi-prefix
+      description: multi-prefix Extension
+      link: http://ircv3.net/specs/extensions/multi-prefix-3.1.html
+      required: true
     account-notify:
       name: account-notify
       description: account-notify Extension
@@ -17,14 +28,6 @@ v3.1:
       name: extended-join
       description: extended-join Extension
       link: http://ircv3.net/specs/extensions/extended-join-3.1.html
-    multi-prefix:
-      name: multi-prefix
-      description: multi-prefix Extension
-      link: http://ircv3.net/specs/extensions/multi-prefix-3.1.html
-    sasl:
-      name: sasl
-      description: SASL
-      link: http://ircv3.net/specs/extensions/sasl-3.1.html
     tls:
       name: tls
       description: tls Extension
@@ -37,6 +40,7 @@ v3.2:
       name: CAP
       description: Capability Negotiation
       link: http://ircv3.net/specs/core/capability-negotiation-3.2.html
+      required: true
     # message-tags:
     #   name: Message Tags
     #   description: Message Tags
@@ -45,10 +49,12 @@ v3.2:
       name: Metadata
       description: Metadata
       link: http://ircv3.net/specs/core/metadata-3.2.html
+      required: true
     monitor:
       name: Monitor
       description: Monitor
       link: http://ircv3.net/specs/core/monitor-3.2.html
+      required: true
     account-tag:
       name: account-tag
       description: account-tag Extension

--- a/_includes/software_list.html
+++ b/_includes/software_list.html
@@ -33,7 +33,7 @@
             </td>
             {% for ext in irc_ver[1].specs %}
             {% capture ext_name %}{{ ext[0] }}{% endcapture %}
-            <td colgroup="2" class="support {% if sw.support[irc_verkey] contains ext_name %}supported{% elsif sw.partial[irc_verkey] contains ext_name %}partial{% elsif sw.na[irc_verkey] contains ext_name %}na{% else %}unsupported{% endif %}">
+            <td colgroup="2" class="support {% if sw.support[irc_verkey] contains ext_name %}supported{% elsif sw.partial[irc_verkey] contains ext_name %}partial{% elsif sw.na[irc_verkey] contains ext_name %}na{% else %}unsupported{% endif %} {% if ext[1].required %}required{% else %}optional{% endif %}">
                 {% if sw.support[irc_verkey] contains ext_name %}
                     {% assign capab = sw.support[irc_verkey][ext_name] %}
                     {% assign default = 'Yes' %}

--- a/css/ircv3-style.css
+++ b/css/ircv3-style.css
@@ -74,6 +74,9 @@ td + td, th + th {
   background-color: #8fea94;
 }
 .sw-table tbody tr:hover .unsupported {
+  background-color: rgba(243, 150, 146, 0.5);
+}
+.sw-table tbody tr:hover .unsupported.required {
   background-color: #f39692;
 }
 .sw-table tbody tr:hover .partial {
@@ -119,8 +122,15 @@ a.irc-extension {
   color: #101010;
 }
 .sw-table .unsupported {
+  background-color: rgb(247, 213, 211);
+  color: #303010;
+}
+.sw-table .unsupported.required {
   background-color: #eeaaa7;
   color: #30100E;
+}
+.sw-table td.required + td.optional {
+  border-left: 5px solid white;
 }
 .sw-table td note desc {
   vertical-align: super;


### PR DESCRIPTION
Preview: http://dump.dequis.org/LKeRZ.html

Current: http://ircv3.net/software/clients.html

Closes #18 

>I think some kind of formatting would make it more clear what clients are required to have in order to be IRCv3.1 compatible.
>
>Or group these columns in the left and separate from the rest by more think vertical line

I also made missing caps that are optional a lighter shade of red, since it's not wrong to not implement those. The current one gives off the appearance that everyone is doing everything wrong (the table is mostly red)