### PR TITLE
Add .travis.yml for testing HTML5 validity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+script:
+  - gem install github-pages
+  - jekyll build --drafts
+  - python2 --version && python2 -m pip --version
+  - python2 -m pip install html5validator --user --upgrade
+  - ~/.local/bin/html5validator --root _site/
+rvm: 2.1
+notifications:
+    email: false
+matrix:
+    fast_finish: true
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
I had this branch in my fork and I thought why to not open a PR in case this is found useful after all. I think I might have mentioned this once at IRC, but I don't remember if anything was said.

What it does is installing github-pages environment, building the site, installing offline HTML5 validator and running it.

If I recall correctly the site doesn't pass and this most likely isn't interesting at all.