### PR TITLE
software: Add a small disclaimer and a link to contribute

### DIFF
--- a/_includes/software_intro.html
+++ b/_includes/software_intro.html
@@ -1,0 +1,5 @@
+This software is compliant natively; other software may be compliant with extensions.
+
+We make a best effort to keep this list up to date but it may deviate from recent releases.
+
+Please help us keep this up to date by <a href="https://github.com/ircv3/ircv3.github.io/blob/master/_data/{{page.data-source-filename}}">contributing a pull request</a>.

--- a/software/clients.md
+++ b/software/clients.md
@@ -2,8 +2,9 @@
 layout: page
 title: Clients
 meta-description: IRCv3 Client Support. This page lists the IRC clients compatible with and supporting IRCv3 features.
+data-source-filename: sw_clients.yml
 ---
-This software is compliant natively; other software may be compliant with extensions.
+{% include software_intro.html %}
 
 <div class="irc-sw-list flexy-list">
 {% for type in site.data.sw_clients %}

--- a/software/libraries.md
+++ b/software/libraries.md
@@ -2,8 +2,9 @@
 layout: page
 title: Libraries
 meta-description: IRCv3 Library Support. This page lists the IRC libraries compatible with and supporting IRCv3 features.
+data-source-filename: sw_libraries.yml
 ---
-This software is compliant natively; other software may be compliant with extensions.
+{% include software_intro.html %}
 
 {% for type in site.data.sw_libraries %}
 {% include software_list.html %}

--- a/software/servers.md
+++ b/software/servers.md
@@ -2,8 +2,9 @@
 layout: page
 title: Servers
 meta-description: IRCv3 Server Support. This page lists the IRC servers compatible with and supporting IRCv3 features.
+data-source-filename: sw_servers.yml
 ---
-This software is compliant natively; other software may be compliant with extensions.
+{% include software_intro.html %}
 
 {% for type in site.data.sw_servers %}
 {% include software_list.html %}


### PR DESCRIPTION
Using the wording suggested by @jwheare yesterday. Made it into an include to avoid duplicating the same thing in all software pages.

Also added `data-source-filename` to the yaml front matter to be able to link to the yaml file in github, which should hopefully be obvious enough.

Preview: http://dump.dequis.org/X7UwB.html