### PR TITLE
Add services support list

### DIFF
--- a/_data/sw_services.yml
+++ b/_data/sw_services.yml
@@ -1,0 +1,25 @@
+- name: Services Packages
+  software:
+    - name: Anope
+      link: http://anope.org
+      support:
+        SASL:
+          - external
+          - plain
+    - name: Atheme Forks
+      link: http://atheme.net
+      support:
+        SASL:
+          - external
+          - plain
+      sublinks:
+        - name: ChatServices
+          link: https://bitbucket.org/chatlounge/chatservices
+        - name: EZtheme
+          link: https://github.com/ElectroCode/eztheme
+        - name: Shaltúre
+          link: https://github.com/shalture/shalture
+        - name: Xtheme
+          link: https://github.com/XthemeOrg/Xtheme
+        - name: Zohlai
+          link: https://github.com/zohlai/zohlai

--- a/_data/validation/sw_list.types.yaml
+++ b/_data/validation/sw_list.types.yaml
@@ -38,3 +38,10 @@ software:
               type: listofanythings
             -
               type: mapofanythings
+        sublinks:
+          type: listofdicts
+          kids:
+            name:
+              type: string
+            link:
+              type: string

--- a/_data/validation/sw_services.meta.yaml
+++ b/_data/validation/sw_services.meta.yaml
@@ -1,0 +1,4 @@
+imports:
+  - sw_list.types.yaml
+root:
+  type: software

--- a/_includes/support_list.html
+++ b/_includes/support_list.html
@@ -9,7 +9,9 @@
 {% endcapture %}
 
 {% if anysupport contains "Y" %}
+{% if hide_support_name %}{% else %}
 #### {% if support_name %}{{ support_name }}{% else %}{{ support[1].name }} Support{% endif %}
+{% endif %}
 
 <div class="sw-table"><table>
     <colgroup>
@@ -37,6 +39,13 @@
                             <i title="{{ site.data.os[name]["name"] }}" class="fa fa-{{ site.data.os[name]["icon"] }} os-support-{{ name | slugify }}"></i>
                         {% endif %}
                     {% endfor %}
+                    </div>
+                {% endif %}
+                {% if sw.sublinks %}
+                    <div class="sw-sublinks">
+                        {% for sublink in sw.sublinks %}
+                            <a href="{{ sublink.link }}">{{ sublink.name }}</a>
+                        {% endfor %}
                     </div>
                 {% endif %}
             </td>

--- a/css/ircv3-style.css
+++ b/css/ircv3-style.css
@@ -155,6 +155,14 @@ a.irc-extension {
 .sw-table td note:hover box {
   display: block;
 }
+.sw-sublinks a:before {
+  content: "- ";
+  opacity: 0.75;
+}
+.sw-sublinks a {
+  display: block;
+  margin-left: 1.5rem;
+}
 
 .navbar, .navbar-inverse .dropdown-menu {
 	background-color: #145960;

--- a/docs/sasl-mechs.md
+++ b/docs/sasl-mechs.md
@@ -17,3 +17,12 @@ IAL primarily uses the same mechanisms as SASL in other protocols. Most commonly
 {% include support_list.html %}
 {% endfor %}
 {% endfor %}
+
+### Services Support
+
+{% for type in site.data.sw_services %}
+{% assign hide_support_name = true %}
+{% for support in site.data.doc_sasl %}
+{% include support_list.html %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This just adds the services support list as discussed in #49. I think these are the main services packages around -- are there any others we should be listing as well?

I don't have it showing a page in the proper 'Software' section, as services packages don't make use of the sort of extensions IRCv3 brings out generally. If this changes or there is more to add along these lines, we can do so later.