### PR TITLE
Updated information about Rust IRC library.

### DIFF
--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -66,13 +66,17 @@
           - away-notify
           - extended-join
           - multi-prefix
+          - sasl
         v3.2:
           - cap
           - account-tag
           - cap-notify
           - chghost
           - monitor
+          - metadata
           - echo-message
           - invite-notify
           - server-time
           - userhost-in-names
+          - batch
+          - sasl


### PR DESCRIPTION
Since this was added, I've updated the Rust IRC library quite a bit. It should support everything except TLS. So, I've updated the information accordingly.