### PR TITLE
servers: Add ircd-hybrid

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -46,6 +46,19 @@
       na:
         v3.1:
           tls: direct TLS only
+    - name: ircd-hybrid
+      link: https://github.com/ircd-hybrid/ircd-hybrid
+      support:
+        v3.1:
+          cap: 7.2.1 +
+          multi-prefix: 7.2.1 +
+          account-notify: 8.2.9 +
+          away-notify: 8.1.0beta1 +
+          extended-join: 8.2.2 +
+        v3.2:
+          chghost: 8.2.11 +
+          invite-notify: 8.2.11 +
+          userhost-in-names: 8.1.14 +
     - name: InspIRCd
       # maintainer: saberuk, attila
       # ref: https://github.com/inspircd/inspircd/issues/1038


### PR DESCRIPTION
This adds [ircd-hybrid](https://github.com/ircd-hybrid/ircd-hybrid) to the server support list. PR submitted on behalf of @miwob

Looks like this:
![ircd-hybrid support table](https://cloud.githubusercontent.com/assets/251281/12598010/8f91e59c-c4d3-11e5-8b57-25f82bbde2c7.png)
