### PR TITLE
participants: Remove IRCAnywhere

### DIFF
--- a/_data/participants.yml
+++ b/_data/participants.yml
@@ -25,8 +25,5 @@
 - name: mammon-ircd
   url: http://www.mammon.io/
 
-- name: IRCAnywhere
-  url: http://ircanywhere.com/
-
 - name: ZNC
   url: http://znc.in/


### PR DESCRIPTION
This removes IRCAnywhere from the list of participants on the website.

The project is no longer maintained, and the guy from it who participated no longer seems to frequent our IRC channel.