### PR TITLE
New charter and code of conduct

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -20,14 +20,17 @@ These extensions are published on this website through backwards-compatible [spe
 
 The direction of these specifications is led by the technical board. The board consists of a broad range of IRC software and specification authors that reflect the community at large. The board will seek to make all decisions by consensus.
 
-Nominations for new members of the board will be considered according to the following criteria
+Nominations for new members of the board will be considered once the following pre-requisites are met:
 
- * Demonstrated support and adoption of the IRCv3 specifications
+ * Demonstrated support of the IRCv3 specifications
+ * Approval from the existing board
+ * Adherence to the [code of conduct](/conduct.html)
+
+Candidates must meet one of the following criteria:
+
  * Developers of widely used IRC software
  * Administrators of IRC networks with at least 1,000 active peak users
  * People who have otherwise contributed materially to the specifications
- * Approval from the existing board
- * Adherence to the [code of conduct](/conduct.html)
 
 We're seeking representation from as many members of the IRC community as possible. If you or your project would be a good candidate for representation, please contact the board. The current members of the board are:
 

--- a/charter.md
+++ b/charter.md
@@ -106,7 +106,7 @@ The main project resources are:
  * The [ircv3/ircv3-specifications](https://github.com/ircv3/ircv3-specifications) Github repository and issue tracker.  This is the
    official repository containing the latest version of the specifications.  Changes may be submitted by pull request. Suggestions may be made by opening an issue.
 
- * The [#ircv3](irc://irc.freenode.net/ircv3) channel at [irc.freenode.net](irc://irc.freenode.net/ircv3).  This is the main discussion space for the working group.
+ * The [#ircv3](ircs://irc.freenode.net:6697/#ircv3) channel at [irc.freenode.net](ircs://irc.freenode.net:6697/#ircv3).  This is the main discussion space for the working group.
 
 Contributions are welcome from anyone in the IRC community; including users, developers, operators, administrators. Feel free to start a discussion on IRC or on the issue tracker if you'd like to contribute.
  

--- a/charter.md
+++ b/charter.md
@@ -26,10 +26,10 @@ Nominations for new members of the board will be considered once the following p
  * Approval from the existing board
  * Adherence to the [code of conduct](/conduct.html)
 
-Candidates must meet one of the following criteria:
+In general, candidates who meet any of the following criteria will be given more consideration
 
  * Developers of widely used IRC software
- * Administrators of IRC networks with at least 1,000 active peak users
+ * Administrators of widely used IRC networks
  * People who have otherwise contributed materially to the specifications
 
 We're seeking representation from as many members of the IRC community as possible. If you or your project would be a good candidate for representation, please contact the board. The current members of the board are:

--- a/charter.md
+++ b/charter.md
@@ -1,56 +1,113 @@
 ---
-title: IRCv3 Working Group Charter
+title: Working group charter
 layout: default
-meta-description: The IRCv3 working group is chartered to prototype, develop and test further incremental changes to the IRC client protocol.
+meta-description: The IRCv3 working group is chartered to prototype, develop and specify further extensions to the IRC client protocol.
 ---
 
-# Charter
+# Working group charter
 
 ---
 
-The IRCv3 working group is chartered to prototype, develop and test further incremental changes to
-the IRC client protocol.  It does not define any other aspect of an IRC network, such as IRC services,
+The IRCv3 working group is chartered to prototype, develop, test and specify further extensions to
+the IRC client protocol. It does not define any other aspect of an IRC network, such as IRC services,
 or the server-to-server protocol, although the changes it develops may require cooperation from vendors
 in both areas.
 
-## Participation
+These extensions are published on this website through backwards-compatible [specifications](/irc/).
 
-Interested stakeholders are encouraged to participate in the group.  We consider stakeholders to be:
 
- * Developers of IRC daemons which are actively used;
- * Developers of IRC clients with widespread usage;
- * Developers of other software relating to the IRC ecosystem with widespread usage
-   (such as IRC services, bots, bouncers, libraries);
- * Developers from IRC networks greater than 1,000 active at-peak users which have adopted
-   the IRCv3 specifications.
+## Technical board
 
-Other users may participate in the group in a semi-moderated fashion.  We encourage developers of new
-software relating to IRC to participate in the public resources.
+The direction of these specifications is led by the technical board. The board consists of a broad range of IRC software and specification authors that reflect the community at large. The board will seek to make all decisions by consensus.
 
-## Resources
+Nominations for new members of the board will be considered according to the following criteria
 
- * The [ircv3/ircv3-specifications](https://github.com/ircv3/ircv3-specifications) Github repository and issue tracker.  The Github repository is the
-   official repository containing the latest version of the official specifications.  Changes are to
-   be submitted using a pull request.  We request that pull requests not be submitted to social
-   media aggregators, as we have no mechanism to moderate the bug tracker efficiently.
+ * Demonstrated support and adoption of the IRCv3 specifications
+ * Developers of widely used IRC software
+ * Administrators of IRC networks with at least 1,000 active peak users
+ * People who have otherwise contributed materially to the specifications
+ * Approval from the existing board
+ * Adherence to the [code of conduct](/conduct.html)
 
- * The [#ircv3](irc://irc.freenode.net/ircv3) channel at [irc.freenode.net](irc://irc.freenode.net/ircv3).  This is the main public space for the working group.
-   You are required to follow specific rules to participate in this IRC channel, else you may be
-   removed at any time.
+We're seeking representation from as many members of the IRC community as possible. If you or your project would be a good candidate for representation, please contact the board. The current members of the board are:
 
-## Ground Rules
+<table>
+    <thead>
+        <tr>
+            <th>IRC nick</th>
+            <th>Github</th>
+            <th>Project</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Attila</td>
+            <td><a href="https://github.com/attilamolnar">attilamolnar</a></td>
+            <td><a href="http://www.inspircd.org/">InspIRCd</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>dan-</td>
+            <td><a href="https://github.com/DanielOaks">DanielOaks</a></td>
+            <td><a href="https://github.com/mammon-ircd/mammon">mammon</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>DarthGandalf</td>
+            <td><a href="https://github.com/DarthGandalf">DarthGandalf</a></td>
+            <td><a href="http://wiki.znc.in/ZNC">ZNC</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>dx</td>
+            <td><a href="https://github.com/dequis">dequis</a></td>
+            <td><a href="https://www.bitlbee.org/">bitlbee</a>/<a href="https://irssi.org/">irssi</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>grawity</td>
+            <td><a href="https://github.com/grawity">grawity</a></td>
+            <td>unaffiliated</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>jwheare</td>
+            <td><a href="https://github.com/jwheare">jwheare</a></td>
+            <td><a href="https://www.irccloud.com/">IRCCloud</a></td>
+            <td>Chair</td>
+        </tr>
+        <tr>
+            <td>M2Ys4U</td>
+            <td><a href="https://github.com/M2Ys4U">M2Ys4U</a></td>
+            <td><a href="https://kiwiirc.com/">Kiwi IRC</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>TingPing</td>
+            <td><a href="https://github.com/TingPing">TingPing</a></td>
+            <td><a href="https://hexchat.github.io/">HexChat</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>NoOneButMe</td>
+            <td><a href="https://github.com/zadr">zadr</a></td>
+            <td><a href="http://colloquy.info/">Colloquy</a></td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>
 
-To ensure smooth operations of the working group, we request that:
+The chair has ultimate responsibility for moving discussions forward and will make decisions in cases where consensus isn't possible, including returning proposals to the drawing board where necessary.
 
- * Participants assume good faith from other participants.  The stakeholders have full moderation
-   privilege over the working group resources and may make moderation decisions if one or more
-   participants is unable to assume good faith.
+## Project resources & Contribution
 
- * Participants do not use social media aggregators to "bomb" working group resources because they
-   do not personally agree with a change being made.
+The main project resources are:
 
- * Participants maintain a respectful and professional atmosphere.  This means no use of coercive
-   threats to force cooperation.
+ * The [ircv3/ircv3-specifications](https://github.com/ircv3/ircv3-specifications) Github repository and issue tracker.  This is the
+   official repository containing the latest version of the specifications.  Changes may be submitted by pull request. Suggestions may be made by opening an issue.
 
- * Participants refrain from soapboxing on the IRC channels.  If there is an issue that needs that
-   level of discussion, a bug or pull request should be filed and discussed on the tracker.
+ * The [#ircv3](irc://irc.freenode.net/ircv3) channel at [irc.freenode.net](irc://irc.freenode.net/ircv3).  This is the main discussion space for the working group.
+
+Contributions are welcome from anyone in the IRC community; including users, developers, operators, administrators. Feel free to start a discussion on IRC or on the issue tracker if you'd like to contribute.
+ 
+ Failure to follow our [code of conduct](/conduct.html) when participating may result in immediate removal from the project resources.

--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,100 @@
+---
+title: Code of conduct
+layout: default
+---
+
+# Code of conduct
+
+---
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is implicitly or explicitly representing the project or community.
+
+## Standards of behaviour
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+* Assuming good faith from other participants unless proven otherwise
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Making coercive threats to try to force changes through without seeking consensus,
+  e.g. "We'll pull out unless you do exactly what we say" / "I will pay others not
+  to implement this specification"
+* Demanding that your issues be prioritised above others
+* Derailing, soapboxing, conspiracy theorising, or other deliberately destructive behaviour
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Moderator responsibilities
+
+Project moderators are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project moderators have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+The current moderation team is:
+<table>
+    <thead>
+        <tr>
+            <th>IRC nick</th>
+            <th>Github</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>dan-</td>
+            <td><a href="https://github.com/DanielOaks">DanielOaks</a></td>
+        </tr>
+        <tr>
+            <td>grawity</td>
+            <td><a href="https://github.com/grawity">grawity</a></td>
+        </tr>
+        <tr>
+            <td>jwheare</td>
+            <td><a href="https://github.com/jwheare">jwheare</a></td>
+        </tr>
+    </tbody>
+</table>
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project moderators on IRC or at
+[community@ircv3.net](mailto:community@ircv3.net).
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Project moderators who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant version 1.4](http://contributor-covenant.org/version/1/4/).

--- a/conduct.md
+++ b/conduct.md
@@ -84,7 +84,7 @@ The current moderation team is:
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project moderators on IRC or at
-[community@ircv3.net](mailto:community@ircv3.net).
+[ircv3-mods@googlegroups.com](mailto:ircv3-mods@googlegroups.com).
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project moderators are
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/conduct.md
+++ b/conduct.md
@@ -87,7 +87,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project moderators on IRC or at
 [community@ircv3.net](mailto:community@ircv3.net).
 All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+is deemed necessary and appropriate to the circumstances. The project moderators are
 obligated to maintain confidentiality with regard to the reporter of an incident.
 
 Project moderators who do not follow or enforce the Code of Conduct in good

--- a/conduct.md
+++ b/conduct.md
@@ -31,8 +31,7 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
+* Unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic


### PR DESCRIPTION
This pull request establishes the proposals from ircv3/ircv3-specifications#233 by updating the charter [[rendered](https://github.com/jwheare/ircv3.github.io/blob/charter-coc-update/charter.md)] and adding a new code of conduct [[rendered](https://github.com/jwheare/ircv3.github.io/blob/charter-coc-update/conduct.md)].

The "Community Council" is renamed to "moderation team" and "BDFN" is renamed to "chair" of the technical board.

The old "Ground rules" are incorporated into the code of conduct, adapted from the latest version of the [Contributor Covenant](http://contributor-covenant.org/) [[1.4](http://contributor-covenant.org/version/1/4/)] [[diff](https://gist.github.com/jwheare/df473e0b24d845e0187d)] that more explicitly spells out unacceptable behaviour, and specifies how abuse is reported and enforced. The moderation team is listed there.

Other documents I researched when putting this together include:
* https://www.npmjs.com/policies/conduct
* https://golang.org/conduct
* https://www.rust-lang.org/conduct.html
* http://hood.ie/code-of-conduct/
* http://citizencodeofconduct.org/

Followups:

* [x] I'd like to set up a <strike>community@ircv3.net</strike> ircv3-mods@googlegroups.com email address that forwards to the moderation team. I'll talk to the relevant people in IRC about this.
* [ ] We need more moderators, if anything to cover more time zones. They need to be people who are prepared to enforce the CoC. Does anyone want to volunteer or nominate someone?
* [ ] Close ircv3/ircv3-specifications#222 and ircv3/ircv3-specifications#233
* [ ] Finalise and merge ircv3/ircv3-specifications#215 adding appropriate amendments to the charter.
* [x] Address #67, either closing it in favour of the technical board listing, or revising it to list "members" rather than "stakeholders"
* [ ] I will be speaking to other projects not currently listed on the technical board to see if we can get a more well-rounded list.