### PR TITLE
Change "IRCv3" in page title from prefix to suffix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>IRCv3 - {{ page.title }}</title>
+    <title>{{ page.title }} - IRCv3</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Andrew Northall">
     <meta name="description" content="{% if page.meta-description %}{{ page.meta-description }}{% else %}IRCv3 Development Community{% endif %}">


### PR DESCRIPTION
This makes browser tab titles easier to compare when many tabs are open.