### PR TITLE
Update charybdis ircv3.2 support

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -22,6 +22,7 @@
           server-time: git
           echo-message: git
           sasl: git
+          invite-notify: git
     - name: Elemental IRCd
       # ref: https://github.com/Elemental-IRCd/elemental-ircd/issues/80
       #      https://github.com/Elemental-IRCd/elemental-ircd/blob/elemental-ircd-7.0-experimental/modules/m_cap.c#L70


### PR DESCRIPTION
Charybdis git now adds support for `invite-notify`.