### PR TITLE
Upcase instances of git to Git

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -145,11 +145,11 @@
       support:
         v3.1:
           cap: 4.2.0
-          multi-prefix: git
+          multi-prefix: Git
           sasl: 4.2.0
           tls: 4.2.0
         v3.2:
-          server-time: git
+          server-time: Git
         SASL:
           - dh-blowfish
           - plain
@@ -198,13 +198,13 @@
         v3.1:
           cap:
           sasl:
-          account-notify: git
-          away-notify: git
-          extended-join: git
-          multi-prefix: git
+          account-notify: Git
+          away-notify: Git
+          extended-join: Git
+          multi-prefix: Git
         v3.2:
-          cap: git
-          userhost-in-names: git
+          cap: Git
+          userhost-in-names: Git
         SASL:
           - external
           - plain

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -13,16 +13,16 @@
           away-notify: 3.4.0 +
           tls: 3.5.0 +
         v3.2:
-          cap: git
+          cap: Git
           monitor:
           userhost-in-names: 3.5.0 +
           chghost: 3.5.0 +
           cap-notify: 3.5.0 +
-          account-tag: git
-          server-time: git
-          echo-message: git
-          sasl: git
-          invite-notify: git
+          account-tag: Git
+          server-time: Git
+          echo-message: Git
+          sasl: Git
+          invite-notify: Git
     - name: Elemental IRCd
       # ref: https://github.com/Elemental-IRCd/elemental-ircd/issues/80
       #      https://github.com/Elemental-IRCd/elemental-ircd/blob/elemental-ircd-7.0-experimental/modules/m_cap.c#L70
@@ -36,7 +36,7 @@
           extended-join: 6.5 +
           away-notify: 6.5 +
         v3.2:
-          chghost: git
+          chghost: Git
           monitor:
     - name: IRCCloud Teams
       # maintainer: jwheare
@@ -81,13 +81,13 @@
           extended-join: 2.0.7 +
           tls: 1.2.0 +
         v3.2:
-          cap: git
-          cap-notify: git
-          chghost: git
-          echo-message: git
-          invite-notify: git
-          monitor: git
-          sasl: git
+          cap: Git
+          cap-notify: Git
+          chghost: Git
+          echo-message: Git
+          invite-notify: Git
+          monitor: Git
+          sasl: Git
           userhost-in-names: 1.2.0 +
     - name: mammon-ircd
       # ref: Capability() calls in https://github.com/mammon-ircd/mammon/search?q=Capability


### PR DESCRIPTION
As per the recomendation of #git, "Git" should be used when referring to the VCS, as opposed to 'git' when referring to the primary implementation.