### PR TITLE
_irc/3.1.md: Add RPL_ISUPPORT link

### DIFF
--- a/_irc/3.1.md
+++ b/_irc/3.1.md
@@ -2,7 +2,7 @@
 layout: page
 title: IRCv3.1
 ---
-Right now the IRCv3 specification is distributed as a series of extension specifications to IRC protocol version 2.7, also known as [RFC1459](http://tools.ietf.org/html/rfc1459). To understand the basis of the IRC version 3 protocol, please read RFC1459 followed by the extension specifications.
+Right now the IRCv3 specification is distributed as a series of extension specifications to IRC protocol version 2.7, also known as [RFC1459](http://tools.ietf.org/html/rfc1459). To understand the basis of the IRC version 3 protocol, please read RFC1459 as well as [the ISUPPORT draft](https://tools.ietf.org/html/draft-brocklesby-irc-isupport-03) followed by the extension specifications.
 
 Each version of IRCv3 contains base extensions, which comprise the core functionality of the IRC version 3 client protocol, and optional extensions, which comprise the extended functionality of the protocol.
 


### PR DESCRIPTION
RPL_ISUPPORT is largely supported by IRCv3 members and afaik is required when supporting the IRCv3 protocol.