### PR TITLE
Add Warren to IRC libraries list, with current IRCv3 support state

### DIFF
--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -110,3 +110,13 @@
           - userhost-in-names
           - batch
           - sasl
+    - name: Warren
+      # ref: https://github.com/CarrotCodes/Warren/blob/develop/src/main/kotlin/engineer/carrot/warren/warren/WarrenRunner.kt#L13
+      link: https://github.com/CarrotCodes/Warren
+      support:
+        v3.1:
+          - cap
+          - multi-prefix
+          - sasl
+        v3.2:
+          - cap


### PR DESCRIPTION
This PR adds [Warren](https://github.com/CarrotCodes/Warren), a Kotlin IRC framework, to the IRCv3 libraries list advertised on the website, along with its current IRCv3 state. By doing so I'm committing to maintaining it for a long while.

The main upstream project from it is [Thump](https://github.com/CarrotCodes/Thump), which is likely used by a few thousand Minecraft players (though I don't track usage statistics, only downloads). I'm currently actively working towards a 1.0 release, though it always remains stable enough to use in Thump.

Please let me know if you'd like me to change anything.

