### PR TITLE
Switch URL for The Lounge from GitHub repo to official website

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -308,7 +308,7 @@
           - plain
     - name: Lounge
       # ref: https://github.com/thelounge/lounge/issues/312
-      link: https://github.com/thelounge/lounge/
+      link: https://thelounge.github.io/
       support:
         v3.1:
           - cap


### PR DESCRIPTION
This is to be consistent to all other entries.
Also, this is the entry point for the software.