### PR TITLE
docs/SASL-mechs: Add Libraries

### DIFF
--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -8,6 +8,8 @@
           - cap
           - multi-prefix
           - sasl
+        SASL:
+          - plain
     - name: cinch
       # ref: https://github.com/cinchrb/cinch/blob/v2.3.1/lib/cinch/irc.rb#L115
       link: https://github.com/cinchrb/cinch
@@ -17,6 +19,8 @@
           - away-notify
           - multi-prefix
           - sasl
+        SASL:
+          - plain
     - name: Communi
       # ref: http://communi.github.io/doc/3.4/ircv3.html
       link: https://communi.github.io
@@ -38,6 +42,8 @@
           userhost-in-names: 3.0+
           account-tag: 3.4+
           chghost: 3.4+
+        SASL:
+          - plain
     - name: Kitteh IRC Client Library
       # ref: http://kicl.kitteh.org/en/stable/ircv3/
       link: https://github.com/KittehOrg/KittehIRCClientLib
@@ -60,6 +66,9 @@
           - sasl
           - server-time
           - userhost-in-names
+        SASL:
+          - external
+          - plain
     - name: Net::Async::IRC
       # ref: https://metacpan.org/source/PEVANS/Net-Async-IRC-0.10/lib/Net/Async/IRC.pm#L339
       link: https://metacpan.org/pod/Net::Async::IRC
@@ -83,6 +92,8 @@
           monitor: 0.8
           chghost:
           userhost-in-names:
+        SASL:
+          - plain
       partial:
         v3.2:
           cap: 0.8.2, except NEW/DEL
@@ -110,6 +121,8 @@
           - userhost-in-names
           - batch
           - sasl
+        SASL:
+          - plain
     - name: Warren
       # ref: https://github.com/CarrotCodes/Warren/blob/develop/src/main/kotlin/engineer/carrot/warren/warren/WarrenRunner.kt#L13
       link: https://github.com/CarrotCodes/Warren
@@ -120,3 +133,5 @@
           - sasl
         v3.2:
           - cap
+        SASL:
+          - plain

--- a/docs/sasl-mechs.md
+++ b/docs/sasl-mechs.md
@@ -18,6 +18,13 @@ IAL primarily uses the same mechanisms as SASL in other protocols. Most commonly
 {% endfor %}
 {% endfor %}
 
+{% for type in site.data.sw_libraries %}
+{% assign support_name = type.name %}
+{% for support in site.data.doc_sasl %}
+{% include support_list.html %}
+{% endfor %}
+{% endfor %}
+
 ### Services Support
 
 {% for type in site.data.sw_services %}


### PR DESCRIPTION
Adds SASL mechanisms for libraries to the best of my abilities. The docs in most cases weren't particularily clear on EXTERNAL or other sasl mechs support. Some libraries like cinch support blowfish but weren't mentioned due to them being deprecated.

It might be worth considering adding another column for 'ecdsa-nist256p-challenge', feel free to comment thoughts about that.

Caps are alphabetically sorted.

![sasl mechs](http://i.imgur.com/vT7cGsz.png)