### PR TITLE
Modify list of CAPs supported by Textual

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -215,7 +215,8 @@
           - external
           - plain
     - name: Textual
-      # ref: https://github.com/Codeux-Software/Textual/blob/v5.2.5/Classes/IRC/IRCClient.m#L5895
+      # ref: https://github.com/Codeux-Software/Textual/blob/v6.0.1/Classes/IRC/IRCClient.m#L7102-L7127
+      # ref: https://github.com/Codeux-Software/Textual/blob/v6.0.1/Classes/IRC/IRCClient.m#L4590
       link: http://www.codeux.com/textual
       support:
         v3.1:
@@ -224,10 +225,13 @@
           - multi-prefix
           - sasl
         v3.2:
+          cap:
+          monitor: 6.0.0
+          echo-message: 6.0.0
           sasl:
           userhost-in-names:
           server-time:
-          batch: 5.2.2
+          batch:
         SASL:
           - external
           - plain


### PR DESCRIPTION
Changes:
• Negotiation for CAP 3.2 is supported as of version v5.1.4.

Commit that introduced this, over a year ago:
https://github.com/Codeux-Software/Textual/commit/6656d0cff61b57da3c4311c8385f3ec56d52c37d

Where CAP 3.2 is requested in latest stable version:
https://github.com/Codeux-Software/Textual/blob/v6.0.1/Classes/IRC/IRCClient.m#L4590

Did not list a specific version for when support for CAP 3.2 was
introduced because it has been supported over a year and majority of
users already have a version that supports it.

• Added echo-message and monitor and list the version as 6.0.0 because
that version was made public less than a month ago.

Reference where these and others are stated they are supported:
https://github.com/Codeux-Software/Textual/blob/v6.0.1/Classes/IRC/IRCClient.m#L7102-L7127

• Removed version (5.2.2) from batch CAP because that version has been
around for some time and is already used by majority of users.

Source: I am developer of Textual