### PR TITLE
data/sw_*: change name `tls` to `starttls`

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -28,9 +28,9 @@ v3.1:
       name: extended-join
       description: extended-join Extension
       link: http://ircv3.net/specs/extensions/extended-join-3.1.html
-    tls:
-      name: tls
-      description: tls Extension
+    starttls:
+      name: starttls
+      description: tls Extension (STARTTLS)
       link: http://ircv3.net/specs/extensions/tls-3.1.html
 
 v3.2:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -11,7 +11,7 @@
           account-notify:
           away-notify:
           extended-join:
-          tls: 1.9.9
+          starttls: 1.9.9
         v3.2:
           server-time: 1.9.7
           userhost-in-names:
@@ -37,7 +37,7 @@
           - account-notify
           - sasl
           - away-notify
-          - tls
+          - starttls
           - extended-join
         v3.2:
           - cap
@@ -145,7 +145,7 @@
           cap: 4.2.0
           multi-prefix: Git
           sasl: 4.2.0
-          tls: 4.2.0
+          starttls: 4.2.0
           account-notify: Git
           extended-join: Git
           away-notify: Git
@@ -176,7 +176,7 @@
         v3.1:
           - cap
           - multi-prefix
-          - tls
+          - starttls
         v3.2:
           - server-time
           - monitor
@@ -382,7 +382,7 @@
           - account-notify
           - sasl
           - away-notify
-          - tls
+          - starttls
           - extended-join
         v3.2:
           - cap
@@ -457,7 +457,7 @@
           - cap
           - multi-prefix
           - sasl
-          - tls
+          - starttls
         v3.2:
           - batch
           - server-time
@@ -520,7 +520,7 @@
           - away-notify
           - extended-join
           - sasl
-          - tls
+          - starttls
         v3.2:
           - cap
           - metadata

--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -86,7 +86,7 @@
           - extended-join
           - multi-prefix
           - sasl
-          - tls
+          - starttls
         v3.2:
           metadata: 0.8.2
           monitor: 0.8

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -11,7 +11,7 @@
           account-notify: 3.4.0 +
           extended-join: 3.4.0 +
           away-notify: 3.4.0 +
-          tls: 3.5.0 +
+          starttls: 3.5.0 +
         v3.2:
           cap: Git
           monitor:
@@ -35,7 +35,7 @@
           account-notify: 1.0.x +
           extended-join: 1.0.x +
           away-notify: 1.0.x +
-          tls: 1.0.x +
+          starttls: 1.0.x +
         v3.2:
           cap: No
           monitor:
@@ -79,7 +79,7 @@
           - userhost-in-names
       na:
         v3.1:
-          tls: direct TLS only
+          starttls: direct TLS only
     - name: ircd-hybrid
       link: https://github.com/ircd-hybrid/ircd-hybrid
       support:
@@ -107,7 +107,7 @@
           account-notify: 2.0.7 +
           away-notify: 2.0.7 +
           extended-join: 2.0.7 +
-          tls: 1.2.0 +
+          starttls: 1.2.0 +
         v3.2:
           cap: Git
           cap-notify: Git
@@ -149,7 +149,7 @@
           sasl: 2013-06-07
           account-notify: 2013-06-02
           extended-join: 2013-06-02
-          tls: 2013-05-26
+          starttls: 2013-05-26
         v3.2:
           userhost-in-names: 2011-12-19
     - name: Oragono
@@ -182,7 +182,7 @@
           account-notify: 0.4.0 +
           away-notify: 0.4.0 +
           extended-join: 0.4.0 +
-          tls: 0.4.0 +
+          starttls: 0.4.0 +
         v3.2:
           cap: 0.4.0 +
           metadata: 0.4.0 +
@@ -206,7 +206,7 @@
           away-notify: 3.2.9 +
           account-notify: 3.2.9 +
           sasl: 3.2.10 +
-          tls: 3.2.10 +
+          starttls: 3.2.10 +
         v3.2:
           userhost-in-names: 3.2.9 +
     - name: BitlBee


### PR DESCRIPTION
As discussed on IRC, using the name `tls` gave the impression this meant the TLS protocol rather than the TLS specification and STARTTLS command. This commit should change the header to `starttls` rather than `tls`.