### PR TITLE
supported networks freenode: change irc.* to chat.*

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -78,8 +78,8 @@
     - name: freenode
       ircd-ver: ircd-seven-1.1.4
       net-address:
-        link: ircs://irc.freenode.net:6697/
-        display: irc.freenode.net
+        link: ircs://chat.freenode.net:6697/
+        display: chat.freenode.net
       link: https://freenode.net/
       support:
         v3.1:


### PR DESCRIPTION
I'm not *confident* if that's changed recently, but as far as I know they prefer chat.*