### PR TITLE
su_networks.yml: Add IRCHighWay

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -88,6 +88,23 @@
           extended-join:
           multi-prefix:
           sasl:
+    - name: IRCHighWay
+      ircd-ver: InspIRCd-2.0
+      net-address:
+        link: ircs://irc.irchighway.net:6697/
+        display: irc.irchighway.net
+      link: https://irchighway.net/
+      support:
+        v3.1:
+          away-notify:
+          account-notify:
+          cap:
+          extended-join:
+          multi-prefix:
+          sasl:
+          starttls:
+        v3.2:
+          userhost-in-names:
     - name: Rizon
       ircd-ver: plexus-4
       net-address:


### PR DESCRIPTION
I asked in the super secret irchighway dev channel a while ago:

```
21:38 < dx> hey do you want to be added here http://ircv3.net/support/networks.html
21:50 <@polyn> dont see why not
22:06 < Andrio> I vote for.
```

(They are netadmin and globalop respectively)