### PR TITLE
Add RSS feed with basic spec updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,29 @@ If you want to test your changes to this website locally before submitting a pul
 6. `jekyll serve`
 
 After you finish those steps, you will be able to go to [http://127.0.0.1:4000/](http://127.0.0.1:4000/) and view a local copy of the website. As you make changes to your files, they will be reflected on that local copy.
+
+## Licenses
+
+The RSS XML feed template was sourced from the [Jekyll RSS Feed Templates](https://github.com/snaptortoise/jekyll-rss-feeds) repo, and is used under this MIT license:
+
+The MIT License (MIT)
+
+Copyright (c) 2014 George Mandis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ name: IRCv3 Working Group
 markdown: kramdown
 highlighter: rouge
 # baseurl: http://ircv3.net
+liveurl: http://ircv3.net  # used in XML feeds
 exclude:
   - README.md
 gems:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 <h2>{{ page.title }}</h2>
+{% if page.author %}<p class="meta">{{ page.author }}</p>{% endif %}
 <p class="meta">{{ page.date | date_to_string }}</p>
 
 <div class="post">

--- a/_posts/2016-11-20-spec-update.md
+++ b/_posts/2016-11-20-spec-update.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Specification Update
+---
+We've got a lot done recently! Let's go through all of the latest changes.
+
+First off, the 3.3 draft message intents was replaced with `message-tags`[<sup>[spec]</sup>](http://ircv3.net/specs/core/message-tags-3.3.html), which looks pretty likely to go in as-is [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/271).
+
+The new draft `message-tags` cap and semantics are more useful than intents, allow more features to be implemented by clients themselves (similar to CTCP) and codify some of the existing meta around clients/servers parsing all well-formed tags.
+
+It was clarified that all message tag / capability / batch names must be handled as opaque identifiers [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/274/files). This was already assumed by most, but is a useful clarification to make for implementors.
+
+Draft capability names now use the `draft/` prefix to denote their status, and to improve transition if specs change before being merged in proper [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/277).
+
+IRCv3.2 Metadata has been **deprecated** [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/279). [IRCv3.3 Metadata](https://github.com/ircv3/ircv3-specifications/pull/250) will extend the rate-limiting and notification capabilities of this spec, letting it be implemented in a much more efficient way by the larger IRC servers.
+
+And for proposals, an [`rfc7700` casemapping PR](https://github.com/ircv3/ircv3-specifications/pull/272) has been submitted, which would allow nicknames and channel names to contain Unicode characters. As well a [extended message length PR](https://github.com/ircv3/ircv3-specifications/pull/281) has been submitted, which would allow servers to accept and send larger IRC messages.

--- a/_posts/2016-11-20-spec-update.md
+++ b/_posts/2016-11-20-spec-update.md
@@ -4,14 +4,16 @@ title: Specification Update
 ---
 We've got a lot done recently! Let's go through all of the latest changes.
 
-First off, the 3.3 draft message intents was replaced with `message-tags`[<sup>[spec]</sup>](http://ircv3.net/specs/core/message-tags-3.3.html), which looks pretty likely to go in as-is [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/271).
+First off, the message intents draft was replaced with `message-tags`[<sup>[spec]</sup>](http://ircv3.net/specs/core/message-tags-3.3.html). The new draft `message-tags` cap and semantics are more useful than intents, allowing features to be implemented by clients themselves (similar to CTCP) and also codifying some of the existing meta around clients/servers parsing all well-formed tags.
 
-The new draft `message-tags` cap and semantics are more useful than intents, allow more features to be implemented by clients themselves (similar to CTCP) and codify some of the existing meta around clients/servers parsing all well-formed tags.
+If you've missed it, the Strict Transport Security (STS) draft [<sup>[link]</sup>](http://ircv3.net/specs/core/sts-3.3.html) is also on the site, and some [testnets](http://ircv3.net/support/networks.html) have support for it as `draft/sts`. The aim of STS is to allow clients to automatically upgrade their plaintext connections to TLS and to subsequently prevent downgrade attacks.
+
+On a related note, the SNI draft [<sup>[link]</sup>](http://ircv3.net/specs/core/sni-3.3.html) is also now on the site, and should help servers present the right certificate to connecting clients.
 
 It was clarified that all message tag / capability / batch names must be handled as opaque identifiers [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/274/files). This was already assumed by most, but is a useful clarification to make for implementors.
 
 Draft capability names now use the `draft/` prefix to denote their status, and to improve transition if specs change before being merged in proper [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/277).
 
-IRCv3.2 Metadata has been **deprecated** [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/279). [IRCv3.3 Metadata](https://github.com/ircv3/ircv3-specifications/pull/250) will extend the rate-limiting and notification capabilities of this spec, letting it be implemented in a much more efficient way by the larger IRC servers.
+IRCv3.2 Metadata has been **deprecated** [<sup>[pr]</sup>](https://github.com/ircv3/ircv3-specifications/pull/279). The new version of [Metadata](https://github.com/ircv3/ircv3-specifications/pull/250) will extend the rate-limiting and notification capabilities of this spec, letting it be implemented in a much more efficient way by the larger IRC servers.
 
 And for proposals, an [`rfc7700` casemapping PR](https://github.com/ircv3/ircv3-specifications/pull/272) has been submitted, which would allow nicknames and channel names to contain Unicode characters. As well a [extended message length PR](https://github.com/ircv3/ircv3-specifications/pull/281) has been submitted, which would allow servers to accept and send larger IRC messages.

--- a/css/ircv3-style.css
+++ b/css/ircv3-style.css
@@ -393,6 +393,15 @@ a:hover, a:focus {
     color: #9fc234;
 }
 
+.post-content {
+    border-left: 1px solid #d7d7d7;
+    padding-left: 2rem
+}
+.meta {
+    color: #444;
+    font-size: 1.25rem;
+}
+
 /* sticky footer */
 html {
   position: relative;

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,27 @@
+---
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<channel>
+		<title>{{ site.name | xml_escape }}</title>
+		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>		
+		<link>{{ site.liveurl }}</link>
+		<atom:link href="{{ site.liveurl }}/{{ page.path }}" rel="self" type="application/rss+xml" />
+		{% for post in site.posts %}
+			<item>
+				<title>{{ post.title | xml_escape }}</title>
+				{% if post.author.name %}
+					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
+				{% endif %}        
+				{% if post.excerpt %}
+					<description>{{ post.excerpt | xml_escape }}</description>
+				{% else %}
+					<description>{{ post.content | xml_escape }}</description>
+				{% endif %}
+				<pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+				<link>{{ site.liveurl }}{{ post.url }}</link>
+				<guid isPermaLink="true">{{ site.liveurl }}{{ post.url }}</guid>
+			</item>
+		{% endfor %}
+	</channel>
+</rss>

--- a/wg.html
+++ b/wg.html
@@ -33,3 +33,25 @@ meta-description: Welcome to the IRCv3 Working Group. We're a group of IRC clien
           <a class="btn btn-lg btn-primary" href="https://github.com/ircv3">View</a>
         </div>
       </div>
+
+</div>
+
+<div id="home-slider-wrapper"><div class="container">
+
+      <h2>IRCv3 WG Updates <a style="padding: 0.2rem 0.6rem; border-radius: 0.4rem; background: #F2F2F2; margin-left: 1rem; font-size: 1.85rem; color: #cc6f0f" href="/feed.xml"><i class="fa fa-rss-square"></i> RSS</a></h2>
+
+      <p style="margin-bottom: 2rem">Below is a rough log of what the IRCv3 working group's been up to including recent changes to specifications and new proposals:</p>
+
+</div></div>
+
+<div class="container">
+
+      {% for post in site.posts limit:10 %}
+      <div class="post">
+          <h3><a href="{{ post.url }}">{{ post.title | xml_escape }}</a> <span class="meta">{{ post.date | date_to_string }}</span></h3>
+          <div class="post-content">
+              {{ post.content }}
+          </div>
+      </div>
+      {% endfor %}
+

--- a/wg.html
+++ b/wg.html
@@ -46,6 +46,13 @@ meta-description: Welcome to the IRCv3 Working Group. We're a group of IRC clien
 
 <div class="container">
 
+      <div class="post">
+          <h3><a href="https://github.com/ircv3/ircv3-specifications/milestone/4">Roadmap</a></h3>
+          <div class="post-content">
+              <p>Our roadmap <a href="https://github.com/ircv3/ircv3-specifications/milestone/4"><sup>[link]</sup></a> always contains info on our direction moving forward, the sort of features we have planned and our priorities.</p>
+          </div>
+      </div>
+
       {% for post in site.posts limit:10 %}
       <div class="post">
           <h3><a href="{{ post.url }}">{{ post.title | xml_escape }}</a> <span class="meta">{{ post.date | date_to_string }}</span></h3>


### PR DESCRIPTION
For some time, people have wanted a way to just subscribe for the occasional update on what we're doing. This PR introduces an RSS feed to let people subscribe for the occasional update on what we're doing, the status of our specs, and recent changes.

This also fills out the WG page a fair bit, which is good. Solves #83 and #103.

Example post:
<img width="1349" alt="screen shot 2016-11-20 at 12 35 41 pm" src="https://cloud.githubusercontent.com/assets/251281/20459903/4e814a58-af1e-11e6-8320-0cf2a90d2663.png">

And how it's displayed on the WG page:
<img width="1350" alt="screen shot 2016-11-20 at 12 35 27 pm" src="https://cloud.githubusercontent.com/assets/251281/20459904/54d32264-af1e-11e6-8eac-0f003bb69ac4.png">
