### PR TITLE
sw_services: rename "Atheme forks" to "Atheme (and forks)"

### DIFF
--- a/_data/sw_services.yml
+++ b/_data/sw_services.yml
@@ -6,7 +6,7 @@
         SASL:
           - external
           - plain
-    - name: Atheme Forks
+    - name: Atheme (and forks)
       link: http://atheme.net
       support:
         SASL:


### PR DESCRIPTION
Atheme is in active development again, so not including it is a bit misleading.