### PR TITLE
irc: Rewrite header, link to Modern docs

### DIFF
--- a/_irc/index.md
+++ b/_irc/index.md
@@ -8,16 +8,19 @@ index: true
 
 IRCv3 specifications build on top of the core IRC protocol. The primary core
 IRC protocol specifications are [RFC1459](http://tools.ietf.org/html/rfc1459),
-[RFC2812](http://tools.ietf.org/html/rfc2812) and [RFC7194](https://tools.ietf.org/html/rfc7194),
-although one of our members has been working on updated core protocol
-specifications [here](http://modern.ircdocs.horse/) which you may find useful
-to consult.
+[RFC2812](http://tools.ietf.org/html/rfc2812) and [RFC7194](https://tools.ietf.org/html/rfc7194).
+To fully understand IRCv3, please read the core IRC protocol specifications
+followed by the IRCv3 specifications.
+
+**Note:** The core IRC protocol specifications have been widely acknowledged to
+be old, out-of-date, and to not fully or accurately describe how the IRC client
+protocol works today. One of our members has been working on updated core
+protocol specifications [here](http://modern.ircdocs.horse/) which you may find
+useful to consult. Look at core protocol specifications and the IRC ecosystem
+itself for a complete picture of how the IRC protocol works today.
 If you have any questions on the core IRC protocol, please feel free to ask us
 [directly]({{site.baseurl}}/contact.html) or with an issue in our
 [feedback](https://github.com/ircv3/ircv3-feedback) Github repository.
-
-To fully understand IRCv3, please read the core IRC protocol specifications
-followed by the IRCv3 specifications.
 
 These specifications are released when they are stable and have been widely
 tested. In the past, the WG released specifications as versioned bundles

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -22,8 +22,8 @@ If you have any questions on the core IRC protocol, please feel free to ask us
 [directly]({{site.baseurl}}/contact.html) or with an issue in our
 [feedback](https://github.com/ircv3/ircv3-feedback) Github repository.
 
-These specifications are released when they are stable and have been widely
-tested. In the past, the WG released specifications as versioned bundles
+The IRCv3 specifications are released when they are stable and have been widely
+tested. In the past the WG released specifications as versioned bundles
 (IRCv3.1, IRCv3.2), but we no longer do this.
 
 Errata updates may be submitted for our specifications. To do so, simply see

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -6,15 +6,21 @@ meta-description: Specifications that the IRCv3 Working Group maintains and dist
 index: true
 ---
 
-Right now the IRCv3 specification is distributed as a series of extension
-specifications to IRC protocol version 2.7, also known as
-[RFC1459](http://tools.ietf.org/html/rfc1459). To understand the basis of the
-IRC version 3 protocol, please read RFC1459 followed by the extension
-specifications.
+IRCv3 specifications build on top of the core IRC protocol. The primary core
+IRC protocol specifications are [RFC1459](http://tools.ietf.org/html/rfc1459)
+and [RFC7192](https://tools.ietf.org/html/rfc7194), although one of our members
+has been working on updated core protocol specifications
+[here](http://modern.ircdocs.horse/) which you may find useful to consult.
+If you have any questions on the core IRC protocol, please feel free to ask us
+[directly]({{site.baseurl}}/contact.html) or with an issue in our
+[feedback](https://github.com/ircv3/ircv3-feedback) Github repository.
 
-IRCv3 is based on a set of specifications. Initially these specifications were
-released as a versioned distribution – these days, however, each specification
-is released when it is stable and has been widely tested.
+To fully understand IRCv3, please read the core IRC protocol specifications
+followed by the IRCv3 specifications.
+
+Initially these specifications were released as a versioned distribution, but
+these days each specification is released when it is stable and has been widely
+tested.
 
 Errata updates may be submitted for our specifications. To do so, simply see
 our [contribution](https://github.com/ircv3/ircv3-specifications/blob/master/CONTRIBUTING.md)

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -7,10 +7,11 @@ index: true
 ---
 
 IRCv3 specifications build on top of the core IRC protocol. The primary core
-IRC protocol specifications are [RFC1459](http://tools.ietf.org/html/rfc1459)
-and [RFC7192](https://tools.ietf.org/html/rfc7194), although one of our members
-has been working on updated core protocol specifications
-[here](http://modern.ircdocs.horse/) which you may find useful to consult.
+IRC protocol specifications are [RFC1459](http://tools.ietf.org/html/rfc1459),
+[RFC2812](http://tools.ietf.org/html/rfc2812) and [RFC7194](https://tools.ietf.org/html/rfc7194),
+although one of our members has been working on updated core protocol
+specifications [here](http://modern.ircdocs.horse/) which you may find useful
+to consult.
 If you have any questions on the core IRC protocol, please feel free to ask us
 [directly]({{site.baseurl}}/contact.html) or with an issue in our
 [feedback](https://github.com/ircv3/ircv3-feedback) Github repository.
@@ -18,9 +19,9 @@ If you have any questions on the core IRC protocol, please feel free to ask us
 To fully understand IRCv3, please read the core IRC protocol specifications
 followed by the IRCv3 specifications.
 
-Initially these specifications were released as a versioned distribution, but
-these days each specification is released when it is stable and has been widely
-tested.
+These specifications are released when they are stable and have been widely
+tested. In the past, the WG released specifications as versioned bundles
+(IRCv3.1, IRCv3.2), but we no longer do this.
 
 Errata updates may be submitted for our specifications. To do so, simply see
 our [contribution](https://github.com/ircv3/ircv3-specifications/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
The current _"IRCv3 Specifications"_ intro is old and a bit crufty. This PR rewrites it to flow a bit more nicely.

In addition, as suggested in https://github.com/ircv3/ircv3-ideas/issues/3 it links to the [Modern docs](http://modern.ircdocs.horse/) as a possible resource to look at. The things to keep in mind here are that the Modern docs are explicitly edited by me, which is why I've tried to use language distancing it from being an IRCv3-created thing.

Here's how it looks:

![IRCv3 Specifications](https://cloud.githubusercontent.com/assets/251281/21415515/5a567000-c856-11e6-9962-9c58032ff0d4.PNG)
