### PR TITLE
services: Remove EZtheme

### DIFF
--- a/_data/sw_services.yml
+++ b/_data/sw_services.yml
@@ -15,8 +15,6 @@
       sublinks:
         - name: ChatServices
           link: https://bitbucket.org/chatlounge/chatservices
-        - name: EZtheme
-          link: https://github.com/ElectroCode/eztheme
         - name: Shaltúre
           link: https://github.com/shalture/shalture
         - name: Xtheme


### PR DESCRIPTION
EZtheme hasn't been updated since 2015-02-12, shortly after the https://github.com/ElectroCode/eztheme repo was created on 2014-12-29

    <SaberUK> it might be a good idea to clean out the list of atheme forks 
    <SaberUK> because some of them are dead
    <SaberUK> eztheme hasnt had commits in two years, shalture/zohlai hasnt had commits in a year,