### PR TITLE
Update support lists for IRCCloud, add client tags, message-ids -> msgid

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -118,13 +118,6 @@ stable:
       draft: true
       caps:
         - draft/labeled-response
-    draft/message-ids:
-      name: draft/message-ids
-      description: Message IDs DRAFT.
-      link: http://ircv3.net/specs/extensions/message-ids.html
-      draft: true
-      caps:
-        - draft/msgid
     draft/message-tags:
       name: draft/message-tags
       description: Message Tags DRAFT.
@@ -132,6 +125,13 @@ stable:
       draft: true
       caps:
         - draft/message-tags-0.2
+    draft/msgid:
+      name: draft/msgid
+      description: Message IDs DRAFT.
+      link: http://ircv3.net/specs/extensions/message-ids.html
+      draft: true
+      tags:
+        - draft/msgid
     draft/sts:
       name: draft/sts
       description: Strict Transport Security DRAFT.
@@ -139,3 +139,18 @@ stable:
       draft: true
       caps:
         - draft/sts
+
+    +draft/react:
+      name: +draft/react
+      description: React client tag DRAFT.
+      link: http://ircv3.net/client-tags/react.html
+      draft: true
+      tags:
+        - +draft/react
+    +draft/reply:
+      name: +draft/reply
+      description: Reply client tag DRAFT.
+      link: http://ircv3.net/client-tags/reply.html
+      draft: true
+      tags:
+        - +draft/reply

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -27,10 +27,11 @@
           starttls:
           userhost-in-names:
           draft/labeled-response:
+          draft/msgid:
           draft/sts:
       partial:
         stable:
-          draft/message-tags: "only draft/message-tags"
+          draft/message-tags: "not latest version"
       na:
         stable:
           sasl-3.1: No Services enabled
@@ -53,10 +54,13 @@
           cap-notify:
           echo-message:
           extended-join:
+          monitor:
           multi-prefix:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
+          draft/msgid:
+          draft/sts:
       na:
         stable:
           starttls: direct TLS only

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -297,7 +297,7 @@
           echo-message:
           extended-join:
           invite-notify:
-          message-tags:
+          monitor:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -305,7 +305,10 @@
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
+          draft/msgid:
           draft/sts:
+          +draft/react:
+          +draft/reply:
         SASL:
           - plain
     - name: Iris
@@ -347,7 +350,6 @@
       support:
         stable:
           cap-3.1:
-          message-tags:
           echo-message:
           multi-prefix:
           server-time:
@@ -456,7 +458,6 @@
           echo-message:
           extended-join:
           invite-notify:
-          message-tags:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -464,6 +465,7 @@
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
+          draft/msgid:
           draft/sts:
         SASL:
           - plain

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -81,11 +81,13 @@
           away-notify:
           echo-message:
           extended-join:
-          message-tags:
+          monitor:
           multi-prefix:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
+          draft/msgid:
+          draft/sts:
       na:
         stable:
           starttls: direct TLS only
@@ -139,7 +141,6 @@
           away-notify:
           echo-message:
           extended-join:
-          message-tags:
           metadata:
           monitor:
           server-time:
@@ -178,8 +179,8 @@
           multi-prefix: 0.1.0+
           server-time: 0.2.0+
           userhost-in-names: 0.1.0+
-          draft/message-ids: 0.6.0+
           draft/message-tags: 0.6.0+
+          draft/msgid: 0.6.0+
           draft/sts: 0.7.0+
       na:
         stable:

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -178,10 +178,6 @@ see messages that other clients on their connection (say, via an IRC bouncer)
 have sent. It does this by echoing messages back to clients after they are
 sent, allowing for these extra features.
 
-A specification describing message IDs will be proposed soon. This should allow
-clients to make full use of this spec and automatically hide duplicate messages
-as appropriate, which come as a result of this extension.
-
 The [`echo-message` spec]({{site.baseurl}}/specs/extensions/echo-message-3.2.html)
 describes which messages are echo'd, and how they are interpreted by clients.
 


### PR DESCRIPTION
* IRCCloud has monitor support and sts on the server now.
* msgid doesn't have a cap, but a tag, draft/message-ids doesn't exist
* removed plain undrafted `message-tags` from support lists
* add client tags to versions file and client support
* remove outdated note for echo-message about upcoming id specs that are now published (its spec needs updating to point to published labeled-response draft)