### PR TITLE
Support table updates

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -56,13 +56,11 @@
           extended-join:
           monitor:
           multi-prefix:
+          sts:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
           draft/msgid:
-      partial:
-        stable:
-          sts: "draft/sts"
       na:
         stable:
           starttls: direct TLS only

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -98,7 +98,6 @@
           chghost:
           extended-join:
           monitor:
-          monitor:
           multi-prefix:
           sasl-3.1:
           starttls:

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -77,11 +77,11 @@
     #   link: https://www.chatspike.net/
     #   support:
     #     stable:
-    #       - cap-3.1
-    #       - multi-prefix
-    #       - sasl-3.1
-    #       - starttls
-    #       - userhost-in-names
+    #       cap-3.1:
+    #       multi-prefix:
+    #       sasl-3.1:
+    #       starttls:
+    #       userhost-in-names:
     - name: EsperNet
       ircd-ver: charybdis-3.5.3
       net-address: 
@@ -90,19 +90,19 @@
       link: https://esper.net
       support:
         stable:
-          - account-notify
-          - away-notify
-          - cap-3.1
-          - cap-3.2
-          - cap-notify
-          - chghost
-          - extended-join
-          - monitor
-          - monitor
-          - multi-prefix
-          - sasl-3.1
-          - starttls
-          - userhost-in-names
+          account-notify:
+          away-notify:
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          chghost:
+          extended-join:
+          monitor:
+          monitor:
+          multi-prefix:
+          sasl-3.1:
+          starttls:
+          userhost-in-names:
     - name: freenode
       ircd-ver: ircd-seven-1.1.4
       net-address:
@@ -111,11 +111,11 @@
       link: https://freenode.net/
       support:
         stable:
-          - account-notify
-          - cap-3.1
-          - extended-join
-          - multi-prefix
-          - sasl-3.1
+          account-notify:
+          cap-3.1:
+          extended-join:
+          multi-prefix:
+          sasl-3.1:
     - name: IRCHighWay
       ircd-ver: InspIRCd-2.0
       net-address:
@@ -124,14 +124,14 @@
       link: https://irchighway.net/
       support:
         stable:
-          - account-notify
-          - away-notify
-          - cap-3.1
-          - extended-join
-          - multi-prefix
-          - sasl-3.1
-          - starttls
-          - userhost-in-names
+          account-notify:
+          away-notify:
+          cap-3.1:
+          extended-join:
+          multi-prefix:
+          sasl-3.1:
+          starttls:
+          userhost-in-names:
     - name: Rizon
       ircd-ver: plexus-4
       net-address:
@@ -140,13 +140,13 @@
       link: https://rizon.net/
       support:
         stable:
-          - away-notify
-          - cap-3.1
-          - chghost
-          - invite-notify
-          - multi-prefix
-          - sasl-3.1
-          - userhost-in-names
+          away-notify:
+          cap-3.1:
+          chghost:
+          invite-notify:
+          multi-prefix:
+          sasl-3.1:
+          userhost-in-names:
     - name: Snoonet
       ircd-ver: InspIRCd-2.0
       net-address:
@@ -155,14 +155,14 @@
       link: https://www.snoonet.org/
       support:
         stable:
-          - account-notify
-          - away-notify
-          - cap-3.1
-          - extended-join
-          - invite-notify
-          - multi-prefix
-          - sasl-3.1
-          - userhost-in-names
+          account-notify:
+          away-notify:
+          cap-3.1:
+          extended-join:
+          invite-notify:
+          multi-prefix:
+          sasl-3.1:
+          userhost-in-names:
       partial:
         stable:
           sts: "draft/sts"

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -18,10 +18,10 @@
           invite-notify: 2.8+
           monitor: 2.9+
           multi-prefix:
-          sasl-3.1: 1.9.9+
+          sasl-3.1:
           sasl-3.2: 3.0+
-          server-time: 1.9.7+
-          starttls: 1.9.9+
+          server-time:
+          starttls:
           userhost-in-names:
         SASL:
           - external
@@ -40,8 +40,8 @@
       link: http://chatzilla.hacksrus.com/
       support:
         stable:
-          cap-3.1: 0.9.91
-          multi-prefix: 0.9.91
+          cap-3.1:
+          multi-prefix:
     - name: Colloquy
       # ref: handleCapWithParameters() in https://github.com/colloquy/colloquy/blob/main/Chat%20Core/MVIRCChatConnection.m
       link: http://www.colloquy.info
@@ -121,9 +121,9 @@
       support:
         stable:
           cap-3.1:
-          monitor: 1.2+
-          multi-prefix: 1.4+
-          sasl-3.1: 1.3+
+          monitor:
+          multi-prefix:
+          sasl-3.1:
         SASL:
           - plain
     - name: Irssi
@@ -161,13 +161,13 @@
         stable:
           account-notify: Git
           away-notify: Git
-          cap-3.1: 4.2.0+
+          cap-3.1:
           chghost: Git
           extended-join: Git
           multi-prefix: Git
-          sasl-3.1: 4.2.0+
+          sasl-3.1:
           server-time: Git
-          starttls: 4.2.0+
+          starttls:
           userhost-in-names: Git
         SASL:
           - dh-blowfish
@@ -214,9 +214,9 @@
       support:
         stable:
           cap-3.1:
-          monitor: 15+
-          multi-prefix: 21+
-          sasl-3.1: 19+
+          monitor:
+          multi-prefix:
+          sasl-3.1:
         SASL:
           - plain
     - name: Quassel
@@ -267,16 +267,16 @@
       link: https://weechat.org
       support:
         stable:
-          account-notify: 1.2+
-          away-notify: 1.0+
+          account-notify:
+          away-notify:
           cap-notify: 1.4+
-          cap-3.1: 0.3.2+
-          extended-join: 1.1+
-          monitor: 0.4.3+
-          multi-prefix: 0.0.1+
-          sasl-3.1: 0.3.2+
-          server-time: 0.4.0+
-          userhost-in-names: 0.4.1+
+          cap-3.1:
+          extended-join:
+          monitor:
+          multi-prefix:
+          sasl-3.1:
+          server-time:
+          userhost-in-names:
         SASL:
           - dh-aes
           - dh-blowfish
@@ -567,20 +567,20 @@
       link: http://znc.in/
       support:
         stable:
-          account-notify: "Git"
-          away-notify: "Git"
-          cap-3.1: "0.094+ client→ZNC,<br/>0.090+ ZNC→server"
-          extended-join: "Git"
-          multi-prefix: "0.094+ client→ZNC,<br/>0.090+ ZNC→server"
-          userhost-in-names: "0.094+ client→ZNC,<br/>0.090+ ZNC→server"
+          account-notify:
+          away-notify:
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          extended-join:
+          multi-prefix:
+          userhost-in-names:
       partial:
         stable:
-          batch: "1.6.0+ as <code>znc.in/batch</code>, Git as <code>batch</code>, client→ZNC only"
-          cap-3.1: "Git, client→ZNC only"
-          cap-notify: "Git, client→ZNC only"
-          echo-message: "Git, client→ZNC only"
-          sasl-3.1: "1.0+, ZNC→server only"
-          server-time: "1.2+ as <code>znc.in/server-time-iso</code>, Git as <code>server-time</code>, client→ZNC only"
+          batch: "client→ZNC only"
+          echo-message: "client→ZNC only"
+          sasl-3.1: "ZNC→server only"
+          server-time: "client→ZNC only"
         SASL:
           external: "ZNC→server only"
           plain: "ZNC→server only"

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -561,7 +561,7 @@
 
 - name: Bouncers
   software:
-    - name: ZNC as Server
+    - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
       #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886
       link: http://znc.in/
@@ -571,14 +571,13 @@
           away-notify: "Git"
           batch: "Git (1.6.0+ as <code>znc.in/batch</code>)"
           cap-3.1:
-          cap-3.2: "Git"
           cap-notify: "Git"
           echo-message: "Git"
           extended-join: "Git"
           multi-prefix:
           server-time: "Git (1.2+ as <code>znc.in/server-time-iso</code>)"
           userhost-in-names:
-    - name: ZNC as Client
+    - name: ZNC (as Client)
       # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
       #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886
       link: http://znc.in/

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -561,29 +561,40 @@
 
 - name: Bouncers
   software:
-    - name: ZNC
+    - name: ZNC as Server
       # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
       #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886
       link: http://znc.in/
       support:
         stable:
-          account-notify:
-          away-notify:
+          account-notify: "Git"
+          away-notify: "Git"
+          batch: "Git (1.6.0+ as <code>znc.in/batch</code>)"
           cap-3.1:
-          cap-3.2:
-          cap-notify:
-          extended-join:
+          cap-3.2: "Git"
+          cap-notify: "Git"
+          echo-message: "Git"
+          extended-join: "Git"
           multi-prefix:
+          server-time: "Git (1.2+ as <code>znc.in/server-time-iso</code>)"
+          userhost-in-names:
+    - name: ZNC as Client
+      # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
+      #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886
+      link: http://znc.in/
+      support:
+        stable:
+          account-notify: "Git"
+          away-notify: "Git"
+          cap-3.1:
+          extended-join: "Git"
+          multi-prefix:
+          sasl-3.1:
           userhost-in-names:
       partial:
-        stable:
-          batch: "client→ZNC only"
-          echo-message: "client→ZNC only"
-          sasl-3.1: "ZNC→server only"
-          server-time: "client→ZNC only"
         SASL:
-          external: "ZNC→server only"
-          plain: "ZNC→server only"
+          external:
+          plain:
 
 - name: Bots
   software:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -590,7 +590,6 @@
           multi-prefix:
           sasl-3.1:
           userhost-in-names:
-      partial:
         SASL:
           external:
           plain:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -12,7 +12,7 @@
           cap-3.1:
           cap-3.2: 3.0+
           cap-notify: 3.0+
-          chghost: 2.5+
+          chghost:
           echo-message: 2.9+
           extended-join:
           invite-notify: 2.8+
@@ -131,9 +131,9 @@
       link: https://irssi.org
       support:
         stable:
-          cap-3.1: 0.8.18+
-          multi-prefix: 0.8.18+
-          sasl-3.1: 0.8.18+
+          cap-3.1:
+          multi-prefix:
+          sasl-3.1:
         SASL:
           - external
           - plain
@@ -248,8 +248,8 @@
           batch:
           cap-3.1:
           cap-3.2:
-          echo-message: 6.0.0+
-          monitor: 6.0.0+
+          echo-message:
+          monitor:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -269,7 +269,7 @@
         stable:
           account-notify:
           away-notify:
-          cap-notify: 1.4+
+          cap-notify:
           cap-3.1:
           extended-join:
           monitor:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -307,6 +307,7 @@
           sasl-3.1:
           sasl-3.2:
           server-time:
+          sts:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
@@ -315,9 +316,6 @@
           +draft/reply:
         SASL:
           - plain
-      partial:
-        stable:
-          sts: "draft/sts"
     - name: Iris
       # ref: https://github.com/atheme/iris/blob/831483f/qwebirc/ircclient.py#L48
       link: http://www.atheme.net/iris.html
@@ -477,15 +475,13 @@
           sasl-3.1:
           sasl-3.2:
           server-time:
+          sts:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
           draft/msgid:
         SASL:
           - plain
-      partial:
-        stable:
-          sts: "draft/sts"
     - name: LimeChat
       # ref: https://github.com/psychs/limechat/blob/2.42/Classes/IRC/IRCClient.m#L3681
       link: http://limechat.net/iphone/

--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -18,20 +18,20 @@
       language: C++
       support:
         stable:
-          account-notify: 3.3+
-          account-tag: 3.4+
-          away-notify: 3.3+
-          cap-3.1: 3.0+
-          cap-notify: 3.4+
-          chghost: 3.4+
-          extended-join: 3.3+
-          invite-notify: 3.0+
-          message-tags: 3.1+
-          monitor: 3.4+
-          multi-prefix: 3.3+
-          sasl-3.2: 3.0+
-          server-time: 3.4+
-          userhost-in-names: 3.0+
+          account-notify:
+          account-tag:
+          away-notify:
+          cap-3.1:
+          cap-notify:
+          chghost:
+          extended-join:
+          invite-notify:
+          message-tags:
+          monitor:
+          multi-prefix:
+          sasl-3.2:
+          server-time:
+          userhost-in-names:
         SASL:
           - plain
     - name: girc

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -83,13 +83,13 @@
           extended-join:
           monitor:
           multi-prefix:
+          sts:
           userhost-in-names:
           draft/labeled-response:
           draft/message-tags:
           draft/msgid:
       partial:
         stable:
-          sts: "draft/sts"
       na:
         stable:
           starttls: direct TLS only

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -20,21 +20,21 @@
         stable:
           cap-3.1:
           cap-3.2: Git
-          cap-notify: 3.5.0+
-          sasl-3.1: 1.1.0+
+          cap-notify:
+          sasl-3.1:
           sasl-3.2: Git
-          account-notify: 3.4.0+
+          account-notify:
           account-tag: Git
-          away-notify: 3.4.0+
-          chghost: 3.5.0+
+          away-notify:
+          chghost:
           echo-message: Git
-          extended-join: 3.4.0+
+          extended-join:
           invite-notify: Git
           monitor:
-          multi-prefix: 1.0+
+          multi-prefix:
           server-time: Git
-          starttls: 3.5.0+
-          userhost-in-names: 3.5.0+
+          starttls:
+          userhost-in-names:
     - name: ChatIRCd
       # dev: Ben / MrC
       # ref: https://bitbucket.org/chatlounge/chatircd/commits/all
@@ -42,18 +42,18 @@
       support:
         stable:
           cap-3.1:
-          cap-notify: 1.1.x+
-          sasl-3.1: 1.0.x+
-          account-notify: 1.0.x+
-          away-notify: 1.0.x+
-          chghost: 1.1.x+
-          extended-join: 1.0.x+
-          invite-notify: 1.1.x+
+          cap-notify:
+          sasl-3.1:
+          account-notify:
+          away-notify:
+          chghost:
+          extended-join:
+          invite-notify:
           monitor:
-          multi-prefix: 1.0.x+
-          sasl: 1.1.x+
-          starttls: 1.0.x+
-          userhost-in-names: 1.1.x+
+          multi-prefix:
+          sasl:
+          starttls:
+          userhost-in-names:
     - name: Elemental IRCd
       # ref: https://github.com/Elemental-IRCd/elemental-ircd/issues/80
       #      https://github.com/Elemental-IRCd/elemental-ircd/blob/elemental-ircd-7.0-experimental/modules/m_cap.c#L70
@@ -61,13 +61,13 @@
       support:
         stable:
           cap-3.1:
-          sasl-3.1: 6.0.0+
-          account-notify: 6.5+
-          away-notify: 6.5+
+          sasl-3.1:
+          account-notify:
+          away-notify:
           chghost: Git
-          extended-join: 6.5+
+          extended-join:
           monitor:
-          multi-prefix: 6.0.0+
+          multi-prefix:
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/
@@ -97,14 +97,14 @@
       link: https://github.com/ircd-hybrid/ircd-hybrid
       support:
         stable:
-          cap-3.1: 7.2.1+
-          account-notify: 8.2.9+
-          away-notify: 8.1.0beta1+
-          chghost: 8.2.11+
-          extended-join: 8.2.2+
-          invite-notify: 8.2.11+
-          multi-prefix: 7.2.1+
-          userhost-in-names: 8.1.14+
+          cap-3.1:
+          account-notify:
+          away-notify:
+          chghost:
+          extended-join:
+          invite-notify:
+          multi-prefix:
+          userhost-in-names:
     - name: InspIRCd
       # maintainer: saberuk, attila
       # ref: https://github.com/inspircd/inspircd/issues/1038
@@ -154,13 +154,13 @@
       support:
         stable:
           cap-3.1:
-          sasl-3.1: 2013-06-07
-          account-notify: 2013-06-02
-          away-notify: 2013-06-02
-          extended-join: 2013-06-02
-          multi-prefix: 2011-12-19
-          starttls: 2013-05-26
-          userhost-in-names: 2011-12-19
+          sasl-3.1:
+          account-notify:
+          away-notify:
+          extended-join:
+          multi-prefix:
+          starttls:
+          userhost-in-names:
     - name: Oragono
       # ref: https://oragono.io/specs.html
       link: https://oragono.io/
@@ -194,36 +194,36 @@
       link: https://github.com/ElementalAlchemist/txircd
       support:
         stable:
-          cap-3.1: 0.4.0+
-          cap-3.2: 0.4.0+
-          cap-notify: 0.4.0+
-          account-notify: 0.4.0+
-          account-tag: 0.4.0+
-          away-notify: 0.4.0+
-          batch: 0.4.0+
-          chghost: 0.4.0+
-          echo-message: 0.4.0+
-          extended-join: 0.4.0+
-          invite-notify: 0.4.0+
-          metadata: 0.4.0+
-          monitor: 0.4.0+
-          multi-prefix: 0.4.0+
-          server-time: 0.4.0+
-          starttls: 0.4.0+
-          userhost-in-names: 0.4.0+
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          account-notify:
+          account-tag:
+          away-notify:
+          batch:
+          chghost:
+          echo-message:
+          extended-join:
+          invite-notify:
+          metadata:
+          monitor:
+          multi-prefix:
+          server-time:
+          starttls:
+          userhost-in-names:
     - name: UnrealIRCd
       # ref: ClientCapabilityAdd() calls in https://github.com/unrealircd/unrealircd/search?q=ClientCapabilityAdd
       #      (src/modules/m_cap.c has four matches, two not shown)
       link: http://www.unrealircd.org
       support:
         stable:
-          cap-3.1: 3.2.9+
-          sasl-3.1: 3.2.10+
-          account-notify: 3.2.9+
-          away-notify: 3.2.9+
-          multi-prefix: 3.2.9+
-          starttls: 3.2.10+
-          userhost-in-names: 3.2.9+
+          cap-3.1:
+          sasl-3.1:
+          account-notify:
+          away-notify:
+          multi-prefix:
+          starttls:
+          userhost-in-names:
       partial:
         stable:
           sts: "draft/sts 4.0.13+"

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -111,19 +111,19 @@
       link: http://www.inspircd.org
       support:
         stable:
-          cap-3.1:
-          cap-3.2: Git
-          cap-notify: Extras
-          sasl-3.1:
-          sasl-3.2: Git
           account-notify:
           away-notify:
-          chghost: Extras
-          echo-message: Extras
+          cap-3.1:
+          cap-3.2: Git
+          cap-notify: Extras / Git
+          chghost: Extras / Git
+          echo-message: Extras / Git
           extended-join:
-          invite-notify: Extras
+          invite-notify: Extras / Git
           monitor: Git
           multi-prefix:
+          sasl-3.1:
+          sasl-3.2: Git
           starttls:
           sts: Extras
           userhost-in-names:

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -115,19 +115,19 @@
         stable:
           cap-3.1:
           cap-3.2: Git
-          cap-notify:
+          cap-notify: Extras
           sasl-3.1:
           sasl-3.2: Git
           account-notify:
           away-notify:
-          chghost:
-          echo-message:
+          chghost: Extras
+          echo-message: Extras
           extended-join:
-          invite-notify:
+          invite-notify: Extras
           monitor: Git
           multi-prefix:
           starttls:
-          sts:
+          sts: Extras
           userhost-in-names:
     - name: mammon-ircd
       # ref: Capability() calls in https://github.com/mammon-ircd/mammon/search?q=Capability

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -5,14 +5,14 @@
       link: https://bitlbee.org/
       support:
         stable:
-          cap-3.1: 3.4.2
-          cap-3.2: 3.4.2
-          sasl-3.1: 3.4.2
-          sasl-3.2: 3.4.2
-          away-notify: 3.4.2
-          extended-join: 3.4.2
-          multi-prefix: 3.4.2
-          userhost-in-names: 3.4.2
+          cap-3.1:
+          cap-3.2:
+          sasl-3.1:
+          sasl-3.2:
+          away-notify:
+          extended-join:
+          multi-prefix:
+          userhost-in-names:
     - name: Charybdis
       # ref: https://github.com/atheme/charybdis/blob/charybdis-3.5.0-test1/modules/m_cap.c#L73
       link: http://www.charybdis.io/
@@ -166,27 +166,27 @@
       link: https://oragono.io/
       support:
         stable:
-          cap-3.1: 0.1.0+
-          cap-3.2: 0.2.0+
-          cap-notify: 0.3.0+
-          sasl-3.1: 0.1.0+
-          sasl-3.2: 0.2.0+
-          account-notify: 0.2.0+
-          account-tag: 0.1.0+
-          away-notify: 0.1.0+
-          chghost: 0.4.0+
-          echo-message: 0.3.0+
-          extended-join: 0.1.0+
-          invite-notify: 0.2.0+
-          monitor: 0.2.0+
-          multi-prefix: 0.1.0+
-          server-time: 0.2.0+
-          userhost-in-names: 0.1.0+
-          draft/message-tags: 0.6.0+
-          draft/msgid: 0.6.0+
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          sasl-3.1:
+          sasl-3.2:
+          account-notify:
+          account-tag:
+          away-notify:
+          chghost:
+          echo-message:
+          extended-join:
+          invite-notify:
+          monitor:
+          multi-prefix:
+          server-time:
+          userhost-in-names:
+          draft/message-tags:
+          draft/msgid:
       partial:
         stable:
-          sts: "draft/sts 0.7.0+"
+          sts: "draft/sts"
       na:
         stable:
           starttls: supports sts
@@ -226,4 +226,4 @@
           userhost-in-names:
       partial:
         stable:
-          sts: "draft/sts 4.0.13+"
+          sts: "draft/sts"

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -113,21 +113,22 @@
       link: http://www.inspircd.org
       support:
         stable:
-          cap-3.1: 1.2.0+
+          cap-3.1:
           cap-3.2: Git
-          cap-notify: Git
-          sasl-3.1: 1.2.0+
+          cap-notify:
+          sasl-3.1:
           sasl-3.2: Git
-          account-notify: 2.0.7+
-          away-notify: 2.0.7+
-          chghost: Git
-          echo-message: Git
-          extended-join: 2.0.7+
-          invite-notify: Git
+          account-notify:
+          away-notify:
+          chghost:
+          echo-message:
+          extended-join:
+          invite-notify:
           monitor: Git
-          multi-prefix: 1.2.0+
-          starttls: 1.2.0+
-          userhost-in-names: 1.2.0+
+          multi-prefix:
+          starttls:
+          sts:
+          userhost-in-names:
     - name: mammon-ircd
       # ref: Capability() calls in https://github.com/mammon-ircd/mammon/search?q=Capability
       link: https://github.com/mammon-ircd/mammon

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -92,7 +92,7 @@
         stable:
       na:
         stable:
-          starttls: direct TLS only
+          starttls: supports sts
     - name: ircd-hybrid
       link: https://github.com/ircd-hybrid/ircd-hybrid
       support:
@@ -182,11 +182,9 @@
           multi-prefix:
           server-time:
           userhost-in-names:
+          sts:
           draft/message-tags:
           draft/msgid:
-      partial:
-        stable:
-          sts: "draft/sts"
       na:
         stable:
           starttls: supports sts

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -88,8 +88,6 @@
           draft/labeled-response:
           draft/message-tags:
           draft/msgid:
-      partial:
-        stable:
       na:
         stable:
           starttls: supports sts

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,3 +2,5 @@
 layout: default
 ---
 {{ content }}
+
+{% include anchors.html %}

--- a/charter.md
+++ b/charter.md
@@ -72,3 +72,5 @@ The main project resources are:
 Contributions are welcome from anyone in the IRC community; including users, developers, operators, administrators. Feel free to start a discussion on IRC or on the issue tracker if you'd like to contribute.
  
 Failure to follow our [code of conduct]({{site.baseurl}}/conduct.html) when participating may result in immediate removal from the project resources.
+
+{% include anchors.html %}

--- a/conduct.md
+++ b/conduct.md
@@ -95,3 +95,5 @@ members of the project's leadership.
 
 This Code of Conduct is adapted from the
 [Contributor Covenant version 1.4](http://contributor-covenant.org/version/1/4/).
+
+{% include anchors.html %}


### PR DESCRIPTION
* Unprefixed STS support
* Drops version qualifiers for releases at least ~1 year old, early prerelease software and draft specs
* Split ZNC into two columns
* Add Extras qualifiers for InspIRCd