### PR TITLE
Add Numerics section to registry page

### DIFF
--- a/_data/registry.yml
+++ b/_data/registry.yml
@@ -1,4 +1,108 @@
+- name: Numerics
+  include_numeric: true
+  include_specs: true
+  values:
+    - numeric: "005"
+      name: RPL_ISUPPORT
+      description: Lists features supported by the server, sent as connection registration is completed.
+      links:
+        - https://modern.ircdocs.horse/#feature-advertisement
+        - https://modern.ircdocs.horse/#rplisupport-005
+        - https://modern.ircdocs.horse/#rplisupport-parameters
+    - numeric: "670"
+      name: RPL_STARTTLS
+      description: Indicates that the client may begin their TLS handshake
+      specs:
+        - starttls
+    - numeric: "691"
+      name: ERR_STARTTLS
+      description: Indicates that `STARTTLS` failed because of an unspecified error
+      specs:
+        - starttls
+    - numeric: "730"
+      name: RPL_MONONLINE
+      description: This numeric indicates to a client that either a target has just become online, or that a target they have added to their monitor list is online
+      specs:
+        - monitor
+    - numeric: "731"
+      name: RPL_MONOFFLINE
+      description: This numeric indicates to a client that either a target has just left the irc network, or that a target they have added to their monitor list is offline
+      specs:
+        - monitor
+    - numeric: "732"
+      name: RPL_MONLIST
+      description: This numeric is returns the list of targets that the client has in their monitor list
+      specs:
+        - monitor
+    - numeric: "733"
+      name: RPL_ENDOFMONLIST
+      description: This numeric indicates the end of a monitor list
+      specs:
+        - monitor
+    - numeric: "734"
+      name: ERR_MONLISTFULL
+      description: This numeric is indicates to a client that their monitor list is full
+      specs:
+        - monitor
+    - numeric: "900"
+      name: RPL_LOGGEDIN
+      description: Indicates that the client is logged in
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "901"
+      name: RPL_LOGGEDOUT
+      description: Indicates that the client has been logged out
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "902"
+      name: ERR_NICKLOCKED
+      description: Indicates that SASL auth failed because the account is currently locked out, held, or otherwise administratively made unavailable
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "903"
+      name: RPL_SASLSUCCESS
+      description: Indicates that SASL auth finished successfully
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "904"
+      name: ERR_SASLFAIL
+      description: Indicates that SASL auth failed because of invalid credentials or other errors not explicitly mentioned by other numerics
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "905"
+      name: ERR_SASLTOOLONG
+      description: Indicates that SASL auth failed because the client-sent `AUTHENTICATE` command was too long (i.e. the parameter longer than 400 bytes)
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "906"
+      name: ERR_SASLABORTED
+      description: Indicates that SASL auth has been aborted because the client sent an `AUTHENTICATE` command with `*` as the parameter
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "907"
+      name: ERR_SASLALREADY
+      description: Indicates that SASL auth failed because the client has already authenticated and the server doesn't support re-authenticating
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+    - numeric: "908"
+      name: RPL_SASLMECHS
+      description: Sends the SASL mechanisms supported by the server, in response to an incorrectly-sent `AUTHENTICATE` message
+      specs:
+        - sasl-3.1
+        - sasl-3.2
+
+
 - name: Capabilities
+  include_numeric: false
+  include_specs: true
   values:
     - name: account-notify
       specs:
@@ -67,6 +171,8 @@
       description: Extends the RPL_NAMREPLY message to contain the full nickmask `(nick!user@host)` of every user, rather than just the nickname.
 
 - name: Tags
+  include_numeric: false
+  include_specs: true
   values:
     - name: account
       specs:
@@ -90,6 +196,8 @@
       description: Sends a reaction to a specific sent message.
 
 - name: Batches
+  include_numeric: false
+  include_specs: true
   values:
     - name: chathistory
       specs:
@@ -105,6 +213,8 @@
       description: Indicates that the given clients are quitting as the result of a netsplit (two servers disconnecting).
 
 - name: Messages
+  include_numeric: false
+  include_specs: true
   values:
     - name: AUTHENTICATE
       specs: 

--- a/_data/validation/registry.meta.yaml
+++ b/_data/validation/registry.meta.yaml
@@ -3,6 +3,10 @@ root:
   kids:
     name:
       type: string
+    include_numeric:
+      type: boolean
+    include_specs:
+      type: boolean
     values:
       type: listofdicts
       kids:
@@ -17,4 +21,7 @@ root:
           required: false
         draft:
           type: boolean
+          required: false
+        links:
+          type: listofstrings
           required: false

--- a/_data/validation/registry.meta.yaml
+++ b/_data/validation/registry.meta.yaml
@@ -12,6 +12,9 @@ root:
       kids:
         name:
           type: string
+        numeric:
+          type: string
+          required: false
         specs:
           type: listofstrings
         description:

--- a/registry.md
+++ b/registry.md
@@ -6,7 +6,7 @@ page-header: >
   IRCv3 Registry
 ---
 
-This page lists the tags, capabilities, commands, batches and metadata keys that have been defined by the IRCv3 Working Group, or are otherwise described by our specifications.
+This page lists the tags, capabilities, commands, batches and metadata keys that have been defined by the IRCv3 Working Group, are described by our specifications, or that we otherwise recommend using.
 
 <div class="irc-sw-list flexy-list">
 {% for type in site.data.registry %}
@@ -21,21 +21,32 @@ This page lists the tags, capabilities, commands, batches and metadata keys that
 <table>
   <thead>
     <tr>
+      {% if type.include_numeric %}<th style="text-align: center">Numeric</th>{% endif %}
       <th>Name</th>
-      <th>Specs</th>
+      {% if type.include_specs %}<th>Specs</th>{% endif %}
       <th>Description</th>
     </tr>
   </thead>
   <tbody>
     {% for val in type.values %}
     <tr>
+      {% if type.include_numeric %}<td style="min-width: 5rem; text-align: center">
+        <tt>{{ val.numeric }}</tt>
+      </td>{% endif %}
       <td style="min-width: 10rem"{% if type.nomono %}{% else %} class="mono"{% endif %}>{{ val.name }}</td>
-      <td style="min-width: 13rem">
+      {% if type.include_specs %}<td style="min-width: 13rem">
         {% for specname in val.specs %}
           <a class="{% if site.data.specs[specname].deprecated %}deprecated{% endif %} {% if site.data.specs[specname].draft %}draft{% endif %}" title="{{ site.data.specs[specname].name }}" href="{{ site.baseurl }}/specs{{ site.data.specs[specname].url }}">{{ site.data.specs[specname].shortname }}</a>{% if site.data.specs[specname].deprecated %}<sup> [deprecated]</sup>{% endif %}{% if site.data.specs[specname].draft %}<sup> [draft]</sup>{% endif %}{% if forloop.last %}{% else %},{% endif %}
         {% endfor %}
+      </td>{% endif %}
+      <td>
+        {{ val.description | markdownify | replace:"<p>","" | replace:"</p>","" }}
+        {% assign i = 1 %}
+        {% for link in val.links %}
+          <sup><a href="{{ link }}">({{i}})</a></sup>
+          {% assign i = i | plus: 1 %}
+        {% endfor %}
       </td>
-      <td>{{ val.description | markdownify | replace:"<p>","" | replace:"</p>","" }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/registry.md
+++ b/registry.md
@@ -31,7 +31,7 @@ This page lists the tags, capabilities, commands, batches and metadata keys that
     {% for val in type.values %}
     <tr>
       {% if type.include_numeric %}<td style="min-width: 5rem; text-align: center">
-        <tt>{{ val.numeric }}</tt>
+        <code>{{ val.numeric }}</code>
       </td>{% endif %}
       <td style="min-width: 10rem"{% if type.nomono %}{% else %} class="mono"{% endif %}>{{ val.name }}</td>
       {% if type.include_specs %}<td style="min-width: 13rem">


### PR DESCRIPTION
Adds a section to the Registry page called Numerics, that simply lists numerics that we define or recommend using (such as `005` as `RPL_ISUPPORT`).

Right now, the ISUPPORT numeric links to the relevant Modern docs sections for it, but whatever works.

<img width="1366" alt="screen shot 2017-11-09 at 2 44 23 am" src="https://user-images.githubusercontent.com/251281/32561422-f0ea6b04-c4f7-11e7-8cf0-5ed376b62ca1.png">