### PR TITLE
Update UnrealIRCd server capabilities

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -226,6 +226,7 @@
           cap-3.1:
           cap-3.2:
           sasl-3.1:
+          sasl-3.2:
           cap-notify:
           account-notify:
           away-notify:

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -224,9 +224,13 @@
       support:
         stable:
           cap-3.1:
+          cap-3.2:
           sasl-3.1:
+          cap-notify:
           account-notify:
           away-notify:
+          chghost:
+          extended-join:
           multi-prefix:
           starttls:
           userhost-in-names:


### PR DESCRIPTION
UnrealIRCd has support for CAP v.3.2, sasl-3.2, cap-notify, extended-join and chghost since version 4.0.16
These changes should be reflected in the listed/supported specs on the IRCv3 working group's site.

The source, with perhaps ones that were overlooked, can be obtained here: https://forums.unrealircd.org/viewtopic.php?f=1&t=8764

Thank you very much for your time and effort in advance.

Regards,

Koragg