### PR TITLE
Deprecate STARTTLS

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -107,6 +107,7 @@ stable:
     starttls:
       name: starttls
       description: tls Extension (STARTTLS)
+      deprecated: true
       link: /specs/extensions/tls-3.1.html
       caps:
         - tls

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -349,11 +349,14 @@ implementing this spec.
 ## [STARTTLS]({{site.baseurl}}/specs/extensions/tls-3.1.html)
 
 STARTTLS allows clients to upgrade their plaintext connections to use TLS
-encryption. It is recommended that clients instead implement STS support.
+encryption. In alignment with [RFC8314](https://tools.ietf.org/html/rfc8314),
+it is recommended that IRC networks use listeners designed for implicit TLS (such
+as those that operate on port 6697) and clients instead implement STS support.
 
-The [`tls` spec]({{site.baseurl}}/specs/extensions/tls-3.1.html) describes how
-the `STARTTLS` command works, as well as how connection registration is changed
-by the introduction of this capability.
+The [`tls` spec]({{site.baseurl}}/specs/extensions/tls-3.1.html) is still
+available for reference. It describes how the `STARTTLS` command works,
+as well as how connection registration is changed by the introduction of
+this capability.
 
 
 {% include anchors.html %}

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -294,17 +294,6 @@ guidelines for clients and servers, allowing them to better detect the TLS
 certificate to send based on the server's hostname.
 
 
-## [STARTTLS]({{site.baseurl}}/specs/extensions/tls-3.1.html)
-
-STARTTLS allows clients to upgrade their plaintext connections to use TLS
-encryption. It is recommended that clients instead implement STS support when
-that is ratified as a stable IRCv3 standard.
-
-The [`tls` spec]({{site.baseurl}}/specs/extensions/tls-3.1.html) describes how
-the `STARTTLS` command works, as well as how connection registration is changed
-by the introduction of this capability.
-
-
 ## [Strict Transport Security (STS)]({{site.baseurl}}/specs/extensions/sts.html)
 
 STS allows clients to be automatically upgraded to use TLS encryption and
@@ -355,6 +344,16 @@ and excessive notifications, which made it impossible for servers in widespread
 use to implement. A new Metadata specification is being written to address
 these issues and overhaul the notification system, so we do not recommend
 implementing this spec.
+
+
+## [STARTTLS]({{site.baseurl}}/specs/extensions/tls-3.1.html)
+
+STARTTLS allows clients to upgrade their plaintext connections to use TLS
+encryption. It is recommended that clients instead implement STS support.
+
+The [`tls` spec]({{site.baseurl}}/specs/extensions/tls-3.1.html) describes how
+the `STARTTLS` command works, as well as how connection registration is changed
+by the introduction of this capability.
 
 
 {% include anchors.html %}


### PR DESCRIPTION
Has already been some discussion on this in #ircv3. I'm in favour of deprecating it for the reasons I outlined there, but happy to see more discussion on the matter.

-----

It's been quite rightly pointed out I should elaborate on reasoning here, so:

* The upgrade message can be silently dropped by an active MitM. Some clients, which are purely opportunistic about the upgrade, will continue connecting in plaintext -- whereas a "proper" TLS-only connection would fail if an insufficient level of security could be established. @dequis has pointed out that this is addressed in the spec, but it still is subject to TOFU (vs e.g. STS preloading, or an explicit option to connect using TLS on port 6697)
* Whilst STARTTLS can provide some protection against a passive Eve, I feel that it's existence is harmful as it offers a false sense of security to users who may not fully appreciate the difference between STARTTLS and TLS (especially given the misleadingly named CAP key).
* We should be pushing STS instead (and preload mechanisms to prevent plaintext connections at the start). We should also push for TLS-only connections in the longer term.