### PR TITLE
Add glirc to Client support list

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -295,6 +295,24 @@
         SASL:
           - ecdsa-nist256p-challenge
           - plain
+    - name: Glirc
+      # ref: https://github.com/glguy/irc-core/blob/v2/src/Client/State/Network.hs#L686-L687
+      link: https://hackage.haskell.org/package/glirc
+      support:
+        stable:
+          account-notify:
+          away-notify:
+          batch:
+          cap-notify:
+          cap-3.1:
+          chghost:
+          extended-join:
+          multi-prefix:
+          sasl-3.1:
+          server-time:
+        SASL:
+          - plain
+          - ecdsa-nist256p-challenge
 
 - name: Web Clients
   software:


### PR DESCRIPTION
glirc is a Haskell based client that's a few years old and probably has dozens of regular users. The source tarball has been downloaded 10195 total times (511 in the last 30 days). It's not a mainstream client, but I make a point to try and support IRCv3 extensions, especially those used by ZNC or freenode.

* https://github.com/glguy/irc-core
* https://hackage.haskell.org/package/glirc