### PR TITLE
Remove abandoned software from the support tables.

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -326,17 +326,6 @@
         SASL:
           - plain
           - scram-sha-256
-    - name: Iris
-      # ref: https://github.com/atheme/iris/blob/831483f/qwebirc/ircclient.py#L48
-      link: https://github.com/atheme-legacy/iris/
-      support:
-        stable:
-          cap-3.1:
-          multi-prefix:
-          sasl-3.1:
-        SASL:
-          - authcookie
-          - plain
     - name: Kiwi IRC
       # ref: https://github.com/kiwiirc/kiwiirc
       link: https://kiwiirc.com
@@ -397,17 +386,6 @@
 
 - name: Mobile Clients
   software:
-    - name: AndChat
-      # ref: link mentions sasl
-      link: http://www.duckspike.net/andchat/
-      os:
-        - android
-      support:
-        stable:
-          cap-3.1:
-          sasl-3.1:
-        SASL:
-          - plain
     - name: IRC for Android
       # ref: link mentions sasl
       link: http://www.countercultured.net/android/
@@ -467,17 +445,6 @@
           cap-3.1:
           sasl-3.1:
           server-time:
-        SASL:
-          - plain
-    - name: IRC7
-      # ref: link mentions sasl
-      link: http://www.windowsphone.com/en-us/store/app/irc/345e96da-fa2a-457f-95ce-f09e6f3b28a3
-      os:
-        - windows-phone
-      support:
-        stable:
-          cap-3.1:
-          sasl-3.1:
         SASL:
           - plain
     - name: IRCCloud

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -40,6 +40,26 @@
           starttls:
           userhost-in-names:
           webirc:
+    - name: ChatIRCd
+      # dev: Ben / MrC
+      # ref: https://bitbucket.org/chatlounge/chatircd/commits/all
+      link: http://www.chatlounge.net/software/
+      support:
+        stable:
+          cap-3.1:
+          cap-notify:
+          sasl-3.1:
+          account-notify:
+          away-notify:
+          chghost:
+          extended-join:
+          invite-notify:
+          monitor:
+          multi-prefix:
+          sasl:
+          starttls:
+          userhost-in-names:
+          webirc:
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -40,41 +40,6 @@
           starttls:
           userhost-in-names:
           webirc:
-    - name: ChatIRCd
-      # dev: Ben / MrC
-      # ref: https://bitbucket.org/chatlounge/chatircd/commits/all
-      link: http://www.chatlounge.net/software/
-      support:
-        stable:
-          cap-3.1:
-          cap-notify:
-          sasl-3.1:
-          account-notify:
-          away-notify:
-          chghost:
-          extended-join:
-          invite-notify:
-          monitor:
-          multi-prefix:
-          sasl:
-          starttls:
-          userhost-in-names:
-          webirc:
-    - name: Elemental IRCd
-      # ref: https://github.com/Elemental-IRCd/elemental-ircd/issues/80
-      #      https://github.com/Elemental-IRCd/elemental-ircd/blob/elemental-ircd-7.0-experimental/modules/m_cap.c#L70
-      link: https://github.com/Elemental-IRCd/elemental-ircd
-      support:
-        stable:
-          cap-3.1:
-          sasl-3.1:
-          account-notify:
-          away-notify:
-          chghost: Git
-          extended-join:
-          monitor:
-          multi-prefix:
-          webirc:
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/
@@ -139,25 +104,6 @@
           sts: Extras / Git
           userhost-in-names:
           webirc:
-    - name: mammon-ircd
-      # ref: Capability() calls in https://github.com/mammon-ircd/mammon/search?q=Capability
-      link: https://github.com/mammon-ircd/mammon
-      support:
-        stable:
-          cap-3.1:
-          cap-3.2:
-          cap-notify:
-          sasl-3.1:
-          sasl-3.2:
-          account-notify:
-          account-tag:
-          away-notify:
-          echo-message:
-          extended-join:
-          metadata:
-          monitor:
-          server-time:
-          userhost-in-names:
     - name: Nefarious IRCu
       # ref: https://github.com/evilnet/nefarious2/blob/2.0/ircd/m_cap.c#L59
       link: https://github.com/evilnet/nefarious2


### PR DESCRIPTION
This removes the apparently-unmaintained software listed in #221. Please refer to that issue for why this software is being removed.

The maintainers of this software (highlighting them to give them a chance to object) are:

- [x] Iris &mdash; @aaronmdjones
- [x] AndChat &mdash; @duckspike
- [ ] IRC7 &mdash; *unknown*

- ~~ChatIRCd &mdash; @MrBenC~~
- [x] Elemental-IRCd &mdash; @Xe
- [x] mammon-ircd &mdash; @DanielOaks 


