### PR TITLE
Update BitBot reference URLs

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -718,7 +718,8 @@
           - plain
           - external
     - name: BitBot
-      #ref: https://github.com/jesopo/bitbot/blob/master/modules/line_handler.py
+      #ref: https://github.com/jesopo/bitbot/blob/master/modules/line_handler/__init__.py
+      #     https://github.com/jesopo/bitbot/blob/master/modules/line_handler/ircv3.py
       #     https://github.com/jesopo/bitbot/blob/master/modules/sasl/__init__.py
       #     https://github.com/jesopo/bitbot/blob/master/modules/sasl/scram.py
       link: https://github.com/jesopo/bitbot


### PR DESCRIPTION
[BitBot](https://github.com/jesopo/bitbot) recently had his protocol parsing code split out in to different files - making the current link to `line_handler.py` invalid.