### PR TITLE
Replace NoOneButMe (Colloquy) with justjanne (Quassel) on tech board

### DIFF
--- a/_data/tc.yml
+++ b/_data/tc.yml
@@ -20,16 +20,17 @@
   projects:
     - "Unaffiliated"
 
+- nick: justJanne
+  github: justjanne
+  projects:
+    - "[Quassel](https://quassel-irc.org/)"
+    - "[Quasseldroid](https://quasseldroid.info/)"
+
 - nick: jwheare
   github: jwheare
   projects:
     - "[IRCCloud](https://www.irccloud.com/)"
   chair: true
-
-- nick: NoOneButMe
-  github: zadr
-  projects:
-    - "[Colloquy](http://colloquy.info/)"
 
 - nick: prawnsalad
   github: prawnsalad


### PR DESCRIPTION
Having discussed this with a few people in private, I'd like to propose this change to the tech board. NoOneButMe (@zadr) hasn't been active in ircv3 for a while, and @justjanne has. Better if we have active representation I think.