### PR TITLE
Fix Willow Chat participants URL

### DIFF
--- a/_data/participants.yml
+++ b/_data/participants.yml
@@ -32,7 +32,7 @@
   url: https://znc.in/
 
 - name: Willow Chat
-  url: https://willow.chat
+  url: https://willowchat.github.io/
 
 - name: Palaver
   url: https://palaverapp.com/


### PR DESCRIPTION
The Willow Chat domain expired and is incredibly expensive to renew, so I've stuck the site back up using GitHub Pages.