### PR TITLE
[message-ids] Ratified, remove draft prefix and update support tables

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -91,6 +91,13 @@ stable:
       name: Monitor
       description: Monitor
       link: /specs/core/monitor-3.2.html
+    msgid:
+      name: msgid
+      description: Message IDs
+      link: /specs/extensions/message-ids.html
+      tags:
+        - msgid
+        - draft/msgid
     multi-prefix:
       name: multi-prefix
       description: multi-prefix Extension
@@ -150,13 +157,6 @@ stable:
         - draft/labeled-response
       tags:
         - draft/label
-    draft/msgid:
-      name: draft/msgid
-      description: Message IDs DRAFT
-      link: /specs/extensions/message-ids.html
-      draft: true
-      tags:
-        - draft/msgid
     draft/setname:
       name: draft/setname
       description: setname DRAFT

--- a/_data/registry.yml
+++ b/_data/registry.yml
@@ -200,7 +200,7 @@
       description: Allows clients to correlate requests with server responses
     - name: msgid
       specs: 
-        - message-ids
+        - msgid
       description: Provides a server supplied unique message ID
     - name: time
       specs:

--- a/_data/registry.yml
+++ b/_data/registry.yml
@@ -200,7 +200,7 @@
       description: Allows clients to correlate requests with server responses
     - name: msgid
       specs: 
-        - msgid
+        - message-ids
       description: Provides a server supplied unique message ID
     - name: time
       specs:

--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -63,7 +63,6 @@ msgid:
   name: Message IDs
   shortname: Message IDs
   url: /extensions/message-ids.html
-  draft: true
 monitor:
   fullname: IRCv3.2 Monitor
   name: Monitor

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -57,8 +57,10 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
+      partial:
+        stable:
+          msgid: "draft tag"
       na:
         stable:
           starttls: direct TLS only
@@ -89,10 +91,10 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
       partial:
         stable:
           message-tags: "draft cap"
+          msgid: "draft tag"
 
 - name: Networks
   note: >

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -23,6 +23,7 @@
           invite-notify:
           message-tags:
           monitor:
+          msgid:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -31,7 +32,6 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
     - name: IRCCloud Teams
       ircd-ver: irccloud-prattle

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -341,6 +341,7 @@
           invite-notify:
           message-tags:
           monitor:
+          msgid:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -348,7 +349,6 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
           +draft/react:
           +draft/reply:
@@ -503,6 +503,7 @@
           extended-join:
           invite-notify:
           message-tags:
+          msgid:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -510,7 +511,6 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
         SASL:
           - plain
@@ -788,6 +788,7 @@
           invite-notify:
           message-tags:
           monitor:
+          msgid:
           multi-prefix:
           sasl-3.1:
           sasl-3.2:
@@ -795,7 +796,6 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
           +draft/reply:
         SASL:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -399,12 +399,12 @@
           server-time:
           userhost-in-names:
           webirc:
-          draft/msgid:
         SASL:
           - plain
       partial:
         stable:
           message-tags: "draft cap"
+          msgid: "draft tag"
     - name: Mibbit
       # ref: http://wiki.mibbit.com/index.php/SASL
       #      does not send CAP LS when connecting to a server
@@ -575,12 +575,12 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
         SASL:
           - plain
       partial:
         stable:
           message-tags: "draft cap"
+          msgid: "draft tag"
     - name: Quasseldroid
       # ref: https://github.com/quassel/quassel/blob/0.13.0/src/common/irccap.h#L134-L166
       link: https://quasseldroid.info/
@@ -637,7 +637,9 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
+      partial:
+        stable:
+          msgid: "draft tag"
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
       #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886

--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -58,13 +58,13 @@
           server-time:
           userhost-in-names:
           webirc:
-          draft/msgid:
         SASL:
           - external
           - plain
       partial:
         stable:
           message-tags: "draft cap"
+          msgid: "draft tag"
     - name: irc-framework
       # ref: https://github.com/kiwiirc/irc-framework/blob/master/docs/ircv3.md
       link: https://github.com/kiwiirc/irc-framework
@@ -86,12 +86,12 @@
           sasl-3.2:
           server-time:
           userhost-in-names:
-          draft/msgid:
         SASL:
           - plain
       partial:
         stable:
           message-tags: "draft cap"
+          msgid: "draft tag"
     - name: Kitteh IRC Client Library
       # ref: http://kicl.kitteh.org/en/stable/ircv3/
       link: https://github.com/KittehOrg/KittehIRCClientLib

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -79,8 +79,10 @@
           sts:
           userhost-in-names:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
+      partial:
+        stable:
+          msgid: "draft tag"
       na:
         stable:
           starttls: supports sts
@@ -168,9 +170,11 @@
           userhost-in-names:
           sts:
           draft/labeled-response:
-          draft/msgid:
           draft/setname:
           webirc:
+      partial:
+        stable:
+          msgid: "draft tag"
       na:
         stable:
           starttls: supports sts

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -205,8 +205,8 @@ identifier on messages (including `PRIVMSG`/`NOTICE`). This allows clients to
 build new features that refer to specific messages, with the knowledge that
 these identifiers will be unique.
 
-The **work-in-progress** [`message-ids` spec]({{site.baseurl}}/specs/extensions/message-ids.html)
-covers the `draft/msgid` tag, how servers should generate message IDs and how
+The [`message-ids` spec]({{site.baseurl}}/specs/extensions/message-ids.html)
+covers the `msgid` tag, how servers should generate message IDs and how
 clients should treat them.
 
 **Note:** Message IDs themselves are used as a foundation for other extensions


### PR DESCRIPTION
I've not updated the tables for InspIRCd or Oragono since I'm not sure if they need version number qualifiers or if their support are in releases yet.