### PR TITLE
Add server-time capability to quassel

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -221,6 +221,7 @@
           sasl-3.1:
           sasl-3.2: 0.13+
           userhost-in-names: 0.13+
+          server-time: Git
         SASL:
           - external
           - plain

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -220,8 +220,8 @@
           multi-prefix: 0.13+
           sasl-3.1:
           sasl-3.2: 0.13+
-          userhost-in-names: 0.13+
           server-time: Git
+          userhost-in-names: 0.13+
         SASL:
           - external
           - plain


### PR DESCRIPTION
## In Short

* Add server-time to the capability list of quassel with version "git"

## Background Information

Quassel supports server-time in the [current Git version](
https://github.com/quassel/quassel/commit/e38846f054ad1766f2e91992a57bbaffd33c7c06).