### PR TITLE
data: Add server-time cap to Quasseldroid

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -599,6 +599,7 @@
           multi-prefix: 0.13+ core
           sasl-3.1:
           sasl-3.2: 0.13+ core
+          server-time: Git core
           userhost-in-names: 0.13+ core
         SASL:
           - plain


### PR DESCRIPTION
## In short
* Add [`server-time` capability](https://ircv3.net/specs/extensions/server-time-3.2.html ) to [Quasseldroid](https://quasseldroid.info/ )
  * Works with the [current Git Quassel core](https://github.com/quassel/quassel/commit/e38846f054ad1766f2e91992a57bbaffd33c7c06 )
  * [Quassel protocol already transmits time information](https://github.com/quassel/quassel/blob/e38846f054ad1766f2e91992a57bbaffd33c7c06/src/common/message.cpp#L38 ), no Quasseldroid update needed

*As this is a very small change, I've skipped the usual breakdown and risk analysis*