### PR TITLE
Update clients.yml due to developer breaching IRCv3 CoC

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -469,25 +469,6 @@
           userhost-in-names:
         SASL:
           - plain
-    - name: Igloo
-      # maintainer: eskimo
-      link: https://iglooirc.com/
-      os:
-        - ios
-      support:
-        stable:
-          account-notify:
-          away-notify:
-          cap-3.1:
-          cap-3.2:
-          cap-notify:
-          chghost:
-          message-tags:
-          sasl-3.1:
-          sasl-3.2:
-          server-time:
-        SASL:
-          - plain
     - name: IRCCloud
       # maintainer: jwheare
       link: https://www.irccloud.com


### PR DESCRIPTION
In events that most are aware of, the developer of the iOS client Igloo has betrayed the trust and support of many members of the IRCv3 community.  Their repeated breach of the IRCv3 conduct document stands to reason that they face consequences equal to their actions, yet,  nothing has been done.  This PR addresses the missing actions that others refuse to take because of their relationship with the developer. 