### PR TITLE
Remove Mutter from Client List

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -511,31 +511,6 @@
           sasl-3.1:
         SASL:
           - plain
-    - name: Mutter
-      # maintainer: blipz
-      link: https://www.mutterirc.com/
-      os:
-        - ios
-      support:
-        stable:
-          account-notify:
-          account-tag:
-          cap-3.1:
-          cap-3.2:
-          away-notify:
-          batch:
-          cap-notify:
-          chghost:
-          extended-join:
-          invite-notify:
-          monitor:
-          multi-prefix:
-          sasl-3.1:
-          sasl-3.2:
-          server-time:
-          userhost-in-names:
-        SASL:
-          - plain
     - name: Palaver
       # maintainer: kylef
       link: https://palaverapp.com/


### PR DESCRIPTION
Development of [Mutter](https://www.mutterirc.com/) has ceased and can no longer download from the App Store. 