### PR TITLE
update oragono caps

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -164,6 +164,7 @@
           invite-notify:
           message-tags: Git
           monitor:
+          msgid:
           multi-prefix:
           server-time:
           userhost-in-names:
@@ -171,9 +172,6 @@
           draft/labeled-response:
           draft/setname:
           webirc:
-      partial:
-        stable:
-          msgid: "draft tag"
       na:
         stable:
           starttls: supports sts

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -162,7 +162,7 @@
           echo-message:
           extended-join:
           invite-notify:
-          message-tags: Git
+          message-tags:
           monitor:
           msgid:
           multi-prefix:


### PR DESCRIPTION
msgid support was released in 1.1.0:

https://github.com/oragono/oragono/blob/1b0e9a0c081852e435a1b760c8b47103c3b586fd/CHANGELOG.md#110---2019-06-27

and is present in the current stable release 1.1.1. Thanks!