### PR TITLE
sw_servers: change bitlbee's server-time from git to 3.6

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -1,7 +1,7 @@
 - name: Servers
   software:
     - name: BitlBee
-      # ref: https://github.com/bitlbee/bitlbee/blob/3.4.2/irc_cap.c#L39
+      # ref: https://github.com/bitlbee/bitlbee/blob/3.6/irc_cap.c#L39
       link: https://bitlbee.org/
       support:
         stable:
@@ -13,7 +13,7 @@
           extended-join:
           multi-prefix:
           userhost-in-names:
-          server-time: Git
+          server-time: 3.6
       na:
         stable:
           webirc:


### PR DESCRIPTION
3.6 got released earlier this year (didn't write a proper announcement in the website for Reasons but i'll get around it, when i tried to access the server today i got fail2ban'd unfairly but that's sorted now)

...i was going to update irssi too, but turns out we botched the cap 3.2 support by not actually sending "CAP LS 302" in the version that got released, so, nothing to update there.