### PR TITLE
Update supported features in Thunderbird

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -200,7 +200,7 @@
           - external
           - plain
     - name: Mozilla Thunderbird
-      # ref: irc{CAP,MultiPrefix,SASL,ServerTime,WatchMonitor}.jsm files in
+      # ref: irc{CAP,EchoMessage,MultiPrefix,SASL,ServerTime,WatchMonitor}.jsm files in
       #      https://searchfox.org/comm-central/source/chat/protocols/irc/
       link: https://www.thunderbird.net/
       support:
@@ -208,6 +208,7 @@
           cap-notify: 72.0+
           cap-3.1:
           cap-3.2: 72.0+
+          echo-message: 73.0+
           monitor:
           multi-prefix:
           sasl-3.1:


### PR DESCRIPTION
We just merged echo-message support into Thunderbird for version 73: https://bugzilla.mozilla.org/show_bug.cgi?id=1601102

I'm unsure why message-tags was never marked as supported, it was added at the same time as server-time support (in https://bugzilla.mozilla.org/show_bug.cgi?id=1302447)

I think #192 just missed that it was a separate entry in the table.