### PR TITLE
_data/sw_clients.yml: swirc: added sasl mechanism scram-sha-256

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -310,6 +310,7 @@
         SASL:
           - ecdsa-nist256p-challenge
           - plain
+          - scram-sha-256
     - name: Glirc
       # ref: https://github.com/glguy/irc-core/blob/v2/src/Client/State/Network.hs#L686-L687
       link: https://hackage.haskell.org/package/glirc
@@ -328,7 +329,7 @@
           server-time:
           sts:
           userhost-in-names:
-          
+
         SASL:
           - plain
           - ecdsa-nist256p-challenge


### PR DESCRIPTION
Swirc now supports SASL auth mechanism SCRAM-SHA-256
