### PR TITLE
Add pounce bouncer to support tables

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -638,6 +638,42 @@
           server-time:
           sts:
           userhost-in-names:
+    - name: pounce (as Server)
+      # ref: https://git.causal.agency/pounce/tree/bounce.h#n63
+      link: https://git.causal.agency/pounce/about/
+      support:
+        stable:
+          account-notify:
+          away-notify:
+          cap-3.1:
+          chghost:
+          extended-join:
+          invite-notify:
+          monitor:
+          multi-prefix:
+          sasl-3.1:
+          server-time:
+          userhost-in-names:
+        SASL:
+          external:
+    - name: pounce (as Client)
+      # ref: https://git.causal.agency/pounce/tree/bounce.h#n63
+      link: https://git.causal.agency/pounce/about/
+      support:
+        stable:
+          account-notify:
+          away-notify:
+          cap-3.1:
+          chghost:
+          extended-join:
+          invite-notify:
+          monitor:
+          multi-prefix:
+          sasl-3.1:
+          userhost-in-names:
+        SASL:
+          external:
+          plain:
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/blob/znc-1.6.1/src/IRCSock.cpp#L809
       #      https://github.com/znc/znc/blob/znc-1.6.1/src/Client.cpp#L886


### PR DESCRIPTION
(I am the author of [pounce](https://git.causal.agency/pounce/about/))

I added this between IRCCloud and ZNC assuming the list was sorted but I now see that KiwiBNC appears after ZNC, so not sure if there's an intended order.