### PR TITLE
data: Add new caps to Quassel and Quasseldroid

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -219,20 +219,26 @@
           - plain
     - name: Quassel
       # ref: https://github.com/quassel/quassel/blob/0.13.0/src/common/irccap.h#L134-L166
+      # Git: https://github.com/quassel/quassel/blob/c144bdee0d8ab0c195b3088f5c6e57e372e526f7/src/common/irccap.h#L178-L194
       link: https://www.quassel-irc.org
       support:
         stable:
           account-notify: 0.13+
+          account-tag: Git
           away-notify: 0.13+
           cap-notify: 0.13+
           cap-3.1:
           cap-3.2: 0.13+
           chghost: 0.13+
+          echo-message: Git (opt in) # Supported, requires manual /CAP REQ to enable
           extended-join: 0.13+
+          invite-notify: Git
+          message-tags: Git
           multi-prefix: 0.13+
           sasl-3.1:
           sasl-3.2: 0.13+
           server-time: Git
+          setname: Git
           userhost-in-names: 0.13+
         SASL:
           - external
@@ -615,25 +621,32 @@
           setname: "draft cap"
     - name: Quasseldroid
       # ref: https://github.com/quassel/quassel/blob/0.13.0/src/common/irccap.h#L134-L166
+      # Git: https://github.com/quassel/quassel/blob/c144bdee0d8ab0c195b3088f5c6e57e372e526f7/src/common/irccap.h#L178-L194
       link: https://quasseldroid.info/
       os:
         - android
       support:
         stable:
           account-notify: 0.13+ core
+          account-tag: Git core
           away-notify: 0.13+ core
           cap-notify: 0.13+ core
           cap-3.1:
           cap-3.2: 0.13+ core
           chghost: 0.13+ core
+          echo-message: Git core (opt in) # Supported, requires manual /CAP REQ to enable
           extended-join: 0.13+ core
+          invite-notify: Git core
+          message-tags: Git core
           multi-prefix: 0.13+ core
           sasl-3.1:
           sasl-3.2: 0.13+ core
           server-time: Git core
+          setname: Git core
           userhost-in-names: 0.13+ core
         SASL:
           - plain
+          # external is supported if configured on the core via the desktop client
     - name: YAAIC
       # ref: https://github.com/pocmo/Yaaic/blob/v1.1/app/src/main/java/org/jibble/pircbot/PircBot.java#L208
       link: https://www.yaaic.org


### PR DESCRIPTION
## In short

* Add the following capabilities to Quassel and Quasseldroid
  * [`account-tag`](https://github.com/quassel/quassel/commit/d778861aa194578cd90e019b64fe285ea58746c4 )
  * [`echo-message`](https://github.com/quassel/quassel/commit/48017b680ede0dbfb121d1184dfbd13536cfc53f )
  * [`invite-notify`](https://github.com/quassel/quassel/commit/e14649614fbbf9b386505a5d782b88b1ac313c1f )
  * [`message-tags`](https://github.com/quassel/quassel/commit/30269231603184696da66adf4503440062df8962 )
  * [`setname`](https://github.com/quassel/quassel/commit/4e40c486dea949244b73beaf73d5ceb1ef591b5b )
* Details
  * `echo-message` is disabled by default until batch and labeled-response are supported
  * Enable `echo-message` in the meantime with `/CAP REQ echo-message`
  * The new capabilities are purely core-side, no client changes required.
  * [See the full tests performed here](https://github.com/quassel/quassel/pull/545 )
* Clarify `SASL EXTERNAL` for Quasseldroid in YAML comments
  * Merely lacks configuration UI, can connect to a Quassel core with a certificate associated

*As this is a very small change, I've skipped the usual breakdown and risk analysis*
