### PR TITLE
Update Snoonet spec support.

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -112,7 +112,7 @@
     #       userhost-in-names:
     - name: EsperNet
       ircd-ver: charybdis-3.5.3
-      net-address: 
+      net-address:
         link: ircs://irc.esper.net:6697/
         display: irc.esper.net
       link: https://esper.net
@@ -179,7 +179,7 @@
           sasl-3.1:
           userhost-in-names:
     - name: Snoonet
-      ircd-ver: InspIRCd-2.0
+      ircd-ver: InspIRCd-3
       net-address:
         link: ircs://irc.snoonet.org:6697/
         display: irc.snoonet.org
@@ -187,14 +187,28 @@
       support:
         stable:
           account-notify:
+          account-tag:
           away-notify:
+          batch:
           cap-3.1:
+          cap-3.2:
+          cap-notify:
+          chghost:
+          echo-message:
           extended-join:
           invite-notify:
+          labeled-response:
+          msgid:
           multi-prefix:
           sasl-3.1:
-          sts:
+          sasl-3.2:
+          server-time:
+          setname:
           userhost-in-names:
+          sts:
+      partial:
+        stable:
+          message-tags: No client tags
     - name: tilde.chat
       ircd-ver: inspircd-3.6.0
       net-address:


### PR DESCRIPTION
All listed specs are supported on servers which are currently in the irc.snoonet.org DNS pool. Some older servers which are linked to the network but not in the DNS pool may not support all specs for a few weeks as we're waiting for them to drain so they can be upgraded.