### PR TITLE
Remove ChatSharp

### DIFF
--- a/_data/sw_libraries.yml
+++ b/_data/sw_libraries.yml
@@ -214,16 +214,3 @@
         SASL:
           - external
           - plain
-    - name: ChatSharp
-      # ref:  https://github.com/SirCmpwn/ChatSharp/blob/master/ChatSharp/Handlers/CapabilityHandlers.cs#L15
-      #       https://github.com/SirCmpwn/ChatSharp/blob/master/ChatSharp/IrcClient.cs#L161
-      link: https://github.com/SirCmpwn/ChatSharp
-      language: C#
-      support:
-        stable:
-          account-notify:
-          cap-3.1:
-          cap-3.2:
-          cap-notify:
-          multi-prefix:
-          server-time:


### PR DESCRIPTION
The [linked repository](https://github.com/SirCmpwn/ChatSharp) does not exist anymore.