### PR TITLE
add pinkieval to Technical Board

### DIFF
--- a/_data/tc.yml
+++ b/_data/tc.yml
@@ -32,6 +32,11 @@
     - "[IRCCloud](https://www.irccloud.com/)"
   chair: true
 
+- nick: pinkieval
+  github: ProgVal
+  projects:
+    - "[Limnoria](https://github.com/ProgVal/Limnoria)"
+
 - nick: prawnsalad
   github: prawnsalad
   projects:


### PR DESCRIPTION
I imagine that it would be better for someone from the current technical board to submit this PR, but I imagine it doesn't practically matter and if not me, who?

pinkieval's a great contributor to spec drafting and has enthusiastically implemented a lot of new things in a heavy hitting popular IRC bot. obvious choice!