### PR TITLE
Remove freenode from the IRCv3 networks list.

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -156,24 +156,6 @@
           sasl-3.1:
           starttls:
           userhost-in-names:
-    - name: freenode
-      ircd-ver: ircd-seven-1.1.9
-      net-address:
-        link: ircs://chat.freenode.net:6697/
-        display: chat.freenode.net
-      link: https://freenode.net/
-      support:
-        stable:
-          account-notify:
-          cap-3.1:
-          cap-notify:
-          extended-join:
-          multi-prefix:
-          sasl-3.1:
-          chghost:
-          away-notify:
-          monitor:
-          starttls:
     - name: IRCHighWay
       ircd-ver: InspIRCd-2.0
       net-address:


### PR DESCRIPTION
- Freenode has recently migrated to a new IRCd so this is no longer valid.
- Consent for it to be listed here was provided by the previous staff team not the the current staff team.
- Freenode staff now also includes someone who is banned from the IRCv3 project for abusing contributors so it feels inappropriate to include it here.