### PR TITLE
Fix yaml validation

### DIFF
--- a/_data/validation/sw_list.types.yaml
+++ b/_data/validation/sw_list.types.yaml
@@ -23,7 +23,7 @@ software:
           type: string
           required: false
         net-address:
-          type: mapofstrings
+          type: dict
           required: false
           kids:
             link:


### PR DESCRIPTION
`net-address.exit-early` is a boolean, and setting `net-address` as
`mapofstring` validated it incorrectly.