### PR TITLE
Deprecate Technical Board

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -14,23 +14,19 @@ in both areas.
 These extensions are published on this website through backwards-compatible [specifications]({{site.baseurl}}/irc/).
 
 
-## Technical board
+## IRCv3 Contributors
 
-The direction of these specifications is led by the technical board. The board consists of a broad range of IRC software and specification authors that reflect the community at large. The board will seek to make all decisions by consensus.
+The direction of these specifications is led by our contributors and the WG Chair. Our contributors consist of a broad range of IRC software and specification authors that reflects the IRC development community at large. We seek to make all decisions by consensus.
 
-Nominations for new members of the board will be considered once the following pre-requisites are met:
+To be listed on this page, contributors must:
 
-- Demonstrated support of the IRCv3 specifications
-- Approval from the existing board
-- Adherence to the [code of conduct]({{site.baseurl}}/conduct.html)
+- Demonstrate support of the IRCv3 specifications
+- Have the approval of the current contributors
+- Adhere to our [code of conduct]({{site.baseurl}}/conduct.html)
 
-In general, candidates who meet any of the following criteria will be given more consideration
+We're seeking representation from as many members of the IRC community as possible. If you or your project would be a good candidate for representation, please contact us!
 
-- Developers of widely used IRC software
-- Administrators of widely used IRC networks
-- People who have otherwise contributed materially to the specifications
-
-We're seeking representation from as many members of the IRC community as possible. If you or your project would be a good candidate for representation, please contact the board. The current members of the board are:
+Here's some of our current contributors:
 
 <table>
     <thead>
@@ -60,7 +56,7 @@ We're seeking representation from as many members of the IRC community as possib
     </tbody>
 </table>
 
-The chair has ultimate responsibility for moving discussions forward and will make decisions in cases where consensus isn't possible, including returning proposals to the drawing board where necessary.
+The chair has ultimate responsibility for moving discussions forward and will make decisions in cases where consensus between contributors isn't possible, including returning proposals to the drawing board where necessary.
 
 ## Project resources & Contribution
 

--- a/charter.md
+++ b/charter.md
@@ -56,7 +56,15 @@ Here's some of our current contributors:
     </tbody>
 </table>
 
-The chair has ultimate responsibility for moving discussions forward and will make decisions in cases where consensus between contributors isn't possible, including returning proposals to the drawing board where necessary.
+
+## Governance
+
+The WG Chair is someone the IRCv3 contributors have designated as the Leader For Now of IRCv3. They're able to move discussions forward and make decisions in cases where consensus between contributors isn't possible. They can also return proposals to the drawing board where necessary.
+
+In extraordinary circumstances, the IRCv3 contributors may decide to depose the WG Chair and replace them with someone else (as we've done [in the past](https://github.com/ircv3/ircv3-specifications/issues/233)). In addition, the Chair may appoint someone else to replace them as Chair.
+
+Ownership of the resources of the IRCv3 WG (including the GitHub org, domains, channel, and moderators email list) are spread across several contributors, to prevent the situation where someone can unilaterally control the WG without support from the contributors.
+
 
 ## Project resources & Contribution
 

--- a/charter.md
+++ b/charter.md
@@ -73,7 +73,7 @@ Ownership of the resources of the IRCv3 WG are spread across several contributor
 | @IRCv3 Twitter account | jwheare |
 | GitHub org | DarthGandalf, jwheare |
 | ircv3-mods List | jwheare |
-| Netlify account | DarthGaldalf |
+| Netlify account | DarthGandalf |
 
 
 ## Project resources & Contribution

--- a/charter.md
+++ b/charter.md
@@ -59,11 +59,11 @@ Here's some of our current contributors:
 
 ## Governance
 
-The WG Chair is someone the IRCv3 contributors have designated as the Leader For Now of IRCv3. They're able to move discussions forward and make decisions in cases where consensus between contributors isn't possible. They can also return proposals to the drawing board where necessary.
+The WG Chair is able to move discussions forward and make decisions in cases where consensus between contributors isn't possible. They can also return proposals to the drawing board where necessary.
 
-In extraordinary circumstances, the IRCv3 contributors may decide to depose the WG Chair and replace them with someone else (as we've done [in the past](https://github.com/ircv3/ircv3-specifications/issues/233)). In addition, the Chair may appoint someone else to replace them as Chair.
+The WG Chair's authority is derived from, and contingent upon, the confidence that the community of contributors places in them.
 
-Ownership of the resources of the IRCv3 WG (including the GitHub org, domains, channel, and moderators email list) are spread across several contributors, to prevent the situation where someone can unilaterally control the WG without support from the contributors.
+Ownership of the resources of the IRCv3 WG are spread across several contributors, to prevent the situation where someone can unilaterally control the WG without support from the contributors. Currently, the IRCv3.net domain is controlled by DarthGandalf, and other project resources are controlled by jwheare.
 
 
 ## Project resources & Contribution

--- a/charter.md
+++ b/charter.md
@@ -63,7 +63,17 @@ The WG Chair is able to move discussions forward and make decisions in cases whe
 
 The WG Chair's authority is derived from, and contingent upon, the confidence that the community of contributors places in them.
 
-Ownership of the resources of the IRCv3 WG are spread across several contributors, to prevent the situation where someone can unilaterally control the WG without support from the contributors. Currently, the IRCv3.net domain is controlled by DarthGandalf, and other project resources are controlled by jwheare.
+Ownership of the resources of the IRCv3 WG are spread across several contributors, to prevent the situation where someone can unilaterally control the WG without support from the contributors.
+
+| Resource | Owner(s) |
+| -------- | ------ |
+| `ircv3.net` domain | DarthGandalf |
+| `ircv3.org` domain | jwheare |
+| `#ircv3` channel | dan-, jwheare |
+| @IRCv3 Twitter account | jwheare |
+| GitHub org | DarthGandalf, jwheare |
+| ircv3-mods List | jwheare |
+| Netlify account | DarthGaldalf |
 
 
 ## Project resources & Contribution

--- a/faq.md
+++ b/faq.md
@@ -24,7 +24,7 @@ Plain and simple, a server's S2S protocol only needs to be understood by that sa
 
 ### Who runs IRCv3?
 
-Originally, we were setup by the Atheme group to develop extensions to the IRC client protocol. These days, the direction of the IRCv3 WG is led by the [technical board]({{site.baseurl}}/charter.html).
+Originally, we were setup by the Atheme group to develop extensions to the IRC client protocol. These days, the direction of the IRCv3 WG is led by [our contributors]({{site.baseurl}}/charter.html) and the WG Chair.
 
 We're just a collection of server, client, and bot/library developers that work together to produce new specifications and try to push IRC forward. Anyone's free to join, and as long as you agree with [our charter](/charter.html) we're happy to get your suggestions, ideas and feedback.
 


### PR DESCRIPTION
The 'Technical Board' as a concept has done a lot more harm than good to v3, particularly in recent months.

We made the TB to balance out a tyrannical chair and basically have some formal way to remove and replace the chair if we ever needed to. Well, we luckily haven't had to, and if we did need to in future we could probably do so without having 'The Technical Board' as a tangible thing (especially given their utter lack of any real power right now).

The current TB has zero power. No voting, no exclusive chatting/submission/etc rights, literally nothing. But the amount of effort we need to expend going through the 'voting' process to add new people to the list, to argue about whether or not someone should go onto the list, and to argue about how many people from each project should be allowed on the list, is mind-boggling.

For more info on why the TB exists as it does today, see these issues:

- https://github.com/ircv3/ircv3-specifications/issues/222
- https://github.com/ircv3/ircv3-specifications/issues/233
- https://github.com/ircv3/ircv3.github.io/pull/71
- https://github.com/ircv3/ircv3.github.io/issues/350

-----

This change replaces the Technical Board list with an informal list of Contributors. It's acknowledged that the list here has no real power and is just to show off and shout out some of the people who contribute to the IRCv3 Working Group.

If people want to be added to the new Contributors list it should be a simple matter of confirming they've been contributing, have been playing nice in the WG / they haven't violated our code of conduct, their details are correct, and then hitting Merge on the PR. It doesn't need to be any more complicated than that.

-----

As far as I'm aware, this roughly matches the wishes of a large part of the v3 group (including the 'technical board') and when I brought doing this up in the past I didn't get any large amount of pushback from the group.