### PR TITLE
IRCCloud support the Bot Mode spec

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -409,6 +409,7 @@
           account-tag:
           away-notify:
           batch:
+          bot-mode:
           cap-notify:
           cap-3.1:
           cap-3.2:


### PR DESCRIPTION
by showing a "BOT" label on messages with the`draft/bot` tag.
Plus, it uses it to interpret `+draft/display-name` on incoming messages.