### PR TITLE
Add WebSockets to support tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ You should make sure your manually installed local versions match that of [GitHu
 5. `git submodule update --init --recursive`
 6. `jekyll serve`
 
+## Adding New Spec
+
+1. Update the `spec` submodule. If the spec's a draft, confirm that it has the `work-in-progress: true` tag in the yaml header of the file.
+2. List the spec on `_irc/index.md`
+3. Add the spec to `_data/irc_versions.yml` - the name here is what's used in the support lists. Look at the `hide-if-no-support` and `hide-on-servers` options, they affect how the support tables are generated. Make sure you put it in the right place sorting-wise.
+4. Add the spec to `_data/specs.yml` - the name here is what's used in the registry. Maybe some other places? I need to merge this and the above file sometime.
+5. Add the relevant support to the data files!
+
 ## Licenses
 
 The RSS XML feed template was sourced from the [Jekyll RSS Feed Templates](https://github.com/snaptortoise/jekyll-rss-feeds) repo, and is used under this MIT license:

--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -178,6 +178,11 @@ stable:
       description: WebIRC Extension
       link: /specs/extensions/webirc.html
       hide-if-no-support: true
+    websockets:
+      name: WebSockets
+      description: WebSockets
+      link: /specs/extensions/websockets.html
+      hide-if-no-support: true
 
     +typing:
       name: +typing

--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -152,6 +152,11 @@ webirc:
   name: WebIRC extension
   shortname: WebIRC
   url: /extensions/webirc.html
+websockets:
+  fullname: WebSocket protocol
+  name: WebSockets
+  shortname: WebSockets
+  url: /extensions/websockets.html
 
 # deprecated specs
 metadata-3.2:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -863,6 +863,9 @@
           utf8only:
         SASL:
           plain:
+      partial:
+        stable:
+          websockets: text only
     - name: soju (as Client)
       # ref: https://git.sr.ht/~emersion/soju/tree/master/upstream.go#L23
       link: https://sr.ht/~emersion/soju
@@ -887,9 +890,6 @@
         SASL:
           external:
           plain:
-      partial:
-        stable:
-          websockets: text only
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/search?q=OnServerCapAvailable+extension%3Acpp
       #      mSupportedCaps in https://github.com/znc/znc/blob/99687b0f2489826d35d59e662aebc9ec6cb34996/src/IRCSock.cpp

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -887,6 +887,9 @@
         SASL:
           external:
           plain:
+      partial:
+        stable:
+          websockets: text only
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/search?q=OnServerCapAvailable+extension%3Acpp
       #      mSupportedCaps in https://github.com/znc/znc/blob/99687b0f2489826d35d59e662aebc9ec6cb34996/src/IRCSock.cpp

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -49,6 +49,7 @@
           utf8only:
           sts:
           webirc:
+          websockets:
       na:
         stable:
           starttls: supports sts
@@ -126,6 +127,7 @@
           sts:
           userhost-in-names:
           webirc:
+          websockets:
     - name: Nefarious IRCu
       # ref: https://github.com/evilnet/nefarious2/blob/2.0/ircd/m_cap.c#L59
       link: https://github.com/evilnet/nefarious2
@@ -223,6 +225,7 @@
           sts:
           userhost-in-names:
           webirc:
+          websockets:
           draft/chathistory: 5.2+
       partial:
         stable:


### PR DESCRIPTION
Listed support for Ergo, InspIRCd, and UnrealIRCd.

I think this is correct? I know Kiwi and Gamja can both connect to Ergo's websockets support, but not sure if that's intentional support or just a byproduct of how the spec's written.

If any other software supports the WS spec, give me a shout in this PR!