### PR TITLE
support lists: Remove vertical overflow+scrollbar + add footer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,4 +280,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.17.2
+   2.2.5

--- a/_includes/support_list.html
+++ b/_includes/support_list.html
@@ -18,36 +18,7 @@
 
 <div class="support-table {{ include.swtype }}"><table>
     <thead>
-        <tr>
-            <th>
-                <!-- Software -->
-            </th>
-            {% for ext in support[1].specs %}{% if ext[1].deprecated %}{% else %}
-                {% capture ext_name %}{{ ext[0] }}{% endcapture %}
-
-                {% capture should_show_spec %}
-                    {% for sw in type.software %}
-                        {% if ext[1].hide-on-servers and type.name contains "Servers" %}
-                            
-                        {% elsif ext[1].hide-if-no-support %}
-                            {% if sw.support[support_key] contains ext_name or sw.partial[support_key] contains ext_name %}
-                                Y
-                            {% endif %}
-                        {% elsif ext[1].draft %}
-                            {% if sw.support[support_key] contains ext_name or sw.partial[support_key] contains ext_name or sw.na[support_key] contains ext_name %}
-                                Y
-                            {% endif %}
-                        {% else %}
-                            Y
-                        {% endif %}
-                    {% endfor %}
-                {% endcapture %}
-
-                {% if should_show_spec contains "Y" %}
-                <th class="{% if ext[1].required %}required{% elsif ext[1].draft %}draft{% else %}optional{% endif %}"><a class="spec-name" title="{{ ext[1].description }}" href="{% if ext[1].ext_link %}{{ ext[1].ext_link }}{% else %}{{ site.baseurl }}{{ ext[1].link }}{% endif %}">{{ ext[1].name }}</a></th>
-                {% endif %}
-            {% endif %}{% endfor %}
-        </tr>
+        {% include support_list_header.html %}
     </thead>
     <tbody>
         {% assign sw_index = 0 %}
@@ -154,6 +125,9 @@
         </tr>
         {% endfor %}
     </tbody>
+    <tfoot>
+        {% include support_list_header.html %}
+    </tfoot>
 </table></div>
 
 {% endif %}

--- a/_includes/support_list_header.html
+++ b/_includes/support_list_header.html
@@ -1,0 +1,30 @@
+        <tr>
+            <th>
+                <!-- Software -->
+            </th>
+            {% for ext in support[1].specs %}{% if ext[1].deprecated %}{% else %}
+                {% capture ext_name %}{{ ext[0] }}{% endcapture %}
+
+                {% capture should_show_spec %}
+                    {% for sw in type.software %}
+                        {% if ext[1].hide-on-servers and type.name contains "Servers" %}
+                            
+                        {% elsif ext[1].hide-if-no-support %}
+                            {% if sw.support[support_key] contains ext_name or sw.partial[support_key] contains ext_name %}
+                                Y
+                            {% endif %}
+                        {% elsif ext[1].draft %}
+                            {% if sw.support[support_key] contains ext_name or sw.partial[support_key] contains ext_name or sw.na[support_key] contains ext_name %}
+                                Y
+                            {% endif %}
+                        {% else %}
+                            Y
+                        {% endif %}
+                    {% endfor %}
+                {% endcapture %}
+
+                {% if should_show_spec contains "Y" %}
+                <th class="{% if ext[1].required %}required{% elsif ext[1].draft %}draft{% else %}optional{% endif %}"><a class="spec-name" title="{{ ext[1].description }}" href="{% if ext[1].ext_link %}{{ ext[1].ext_link }}{% else %}{{ site.baseurl }}{{ ext[1].link }}{% endif %}">{{ ext[1].name }}</a></th>
+                {% endif %}
+            {% endif %}{% endfor %}
+        </tr>

--- a/css/partials/_swtable.scss
+++ b/css/partials/_swtable.scss
@@ -20,9 +20,8 @@
 }
 
 .support-table {
-  overflow: auto;
+  overflow-x: auto;
   margin: 0 auto;
-  max-height: 90vh;
 
   + .support-table {
     margin-top: 2em;


### PR DESCRIPTION
The overflow+scrollbar makes tables look weird, and I find them hard to use.

This is because vertical scrollbar within a webpage are not very
natural, but we needed them for headers to remain in sight.

With the header repeated at the bottom, this is no longer needed.
Not to mention the header is sticky when scrolling down the page anyway.