### PR TITLE
Allow support table to break outside the container max width

### DIFF
--- a/css/partials/_swtable.scss
+++ b/css/partials/_swtable.scss
@@ -20,6 +20,9 @@
 }
 
 .support-table {
+  width: 96vw;
+  position: relative;
+  left: calc(-48vw + 50%);
   overflow: auto;
   margin: 0 auto;
   max-height: 90vh;


### PR DESCRIPTION
This prevents punishing people with bigger screens