### PR TITLE
Update support tables for Srain

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -369,10 +369,14 @@
           cap-notify:
           cap-3.1:
           cap-3.2:
+          invite-notify:
           sasl-3.1:
           sasl-3.2:
+          server-time:
+          utf8only:
         SASL:
           - plain
+          - external
     - name: Swirc
       # ref: https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md
       link: https://www.nifty-networks.net/swirc/


### PR DESCRIPTION
Refs:

* https://github.com/SrainApp/srain/releases/tag/1.3.0 for UTF8ONLY
* https://github.com/SrainApp/srain/releases/tag/1.4.0 for the rest

Technically, message-tags is supported too, but it is simply ignored for now.

cc @SilverRainZ