### PR TITLE
Add KiwiIRC's support for chathistory

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -526,6 +526,7 @@
           cap-3.1:
           cap-3.2:
           cap-notify:
+          chathistory:
           chghost:
           echo-message:
           extended-join:


### PR DESCRIPTION
it seems to be missing from the table

ref: https://github.com/kiwiirc/kiwiirc/commits/0f3cab9680d418ef8bf6902e392e6f89fc26a198/src/libs/ChathistoryMiddleware.js