### PR TITLE
Add capability account-tag for WeeChat client

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -420,6 +420,7 @@
       support:
         stable:
           account-notify:
+          account-tag: 3.5+
           away-notify:
           cap-notify:
           cap-3.1:


### PR DESCRIPTION
Since WeeChat 3.5, all IRC tags in messages are stored inside the message displayed (weechat/weechat#1680).
They are not visible but the `/filter` command can be used to filter on some tags, including the account one.