### PR TITLE
Add Dalek to sw_services.yml

### DIFF
--- a/_data/sw_services.yml
+++ b/_data/sw_services.yml
@@ -22,8 +22,8 @@
           - external
           - plain
     - name: Dalek
-          link: https://github.com/DalekIRC/Dalek-Services
-          support:
-            SASL:
-              - external
-              - plain
+      link: https://github.com/DalekIRC/Dalek-Services
+      support:
+        SASL:
+          - external
+          - plain

--- a/_data/sw_services.yml
+++ b/_data/sw_services.yml
@@ -21,3 +21,9 @@
         SASL:
           - external
           - plain
+    - name: Dalek
+          link: https://github.com/DalekIRC/Dalek-Services
+          support:
+            SASL:
+              - external
+              - plain


### PR DESCRIPTION
Dalek is a set of IRC services designed to work with WordPress.
Currently these services support  the following IRCv3 features:

- draft/account-registration (email required, no verify)
- SASL (plain, external)
- draft/channel-context (message-tags)
- msgid and replies (message-tags)
- TAGMSG (with callable hook for TAGMSG for coders)

And more.