### PR TITLE
Update specs and promote extended-monitor to non-draft

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -78,6 +78,12 @@ stable:
       link: /specs/extensions/extended-join.html
       caps:
         - extended-join
+    extended-monitor:
+      name: extended-monitor
+      description: Extended Monitor
+      link: /specs/extensions/extended-monitor.html
+      caps:
+        - extended-monitor
     invite-notify:
       name: invite-notify
       description: invite-notify Extension
@@ -212,14 +218,6 @@ stable:
       draft: true
       caps:
         - draft/channel-rename
-
-    extended-monitor:
-      name: draft/extended-monitor
-      description: Extended Monitor DRAFT
-      link: /specs/extensions/extended-monitor.html
-      draft: true
-      caps:
-        - extended-monitor
 
     multiline:
       name: draft/multiline

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -23,7 +23,6 @@
           chghost:
           echo-message:
           extended-join:
-          extended-monitor:
           invite-notify:
           labeled-response:
           message-tags:
@@ -42,6 +41,7 @@
       partial:
         stable:
           bot-mode: Draft
+          extended-monitor: Draft
     - name: InspIRCd Testnet
       ircd-ver: InspIRCd-3
       net-address:
@@ -126,7 +126,6 @@
           cap-notify:
           chghost:
           chathistory:
-          extended-monitor:
           echo-message:
           extended-join:
           invite-notify:
@@ -147,6 +146,7 @@
       partial:
         stable:
           bot-mode: Draft
+          extended-monitor: Draft
 
 - name: Networks
   note: >
@@ -413,7 +413,6 @@
           account-registration:
           channel-rename:
           chathistory:
-          extended-monitor:
           chghost:
           echo-message:
           extended-join:
@@ -435,3 +434,4 @@
       partial:
         stable:
           bot-mode: Draft
+          extended-monitor: Draft

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -466,7 +466,6 @@
           account-registration:
           channel-context-client-tag:
           chathistory:
-          extended-monitor:
           echo-message:
           extended-join:
           invite-notify:
@@ -483,6 +482,9 @@
           whox:
         SASL:
           - plain
+      partial:
+        stable:
+          extended-monitor: "draft cap"
     - name: IRCCloud
       # maintainer: jwheare
       link: https://www.irccloud.com
@@ -500,7 +502,6 @@
           chghost:
           echo-message:
           extended-join:
-          extended-monitor:
           invite-notify:
           message-tags:
           monitor:
@@ -521,6 +522,9 @@
         SASL:
           - plain
           - scram-sha-256
+      partial:
+        stable:
+          extended-monitor: "draft cap"
     - name: Kiwi IRC
       # ref: https://github.com/kiwiirc/kiwiirc
       #      https://github.com/kiwiirc/irc-framework/blob/v4.10.0/docs/ircv3.md
@@ -709,7 +713,6 @@
           chghost:
           echo-message:
           extended-join:
-          extended-monitor:
           invite-notify:
           labeled-response:
           message-tags:
@@ -728,6 +731,9 @@
         SASL:
           - plain
           - scram-sha-256
+      partial:
+        stable:
+          extended-monitor: "draft cap"
     - name: LimeChat
       # ref: https://github.com/psychs/limechat/blob/2.42/Classes/IRC/IRCClient.m#L3681
       link: http://limechat.net/iphone/
@@ -816,7 +822,6 @@
           cap-3.2:
           cap-notify:
           chathistory:
-          extended-monitor:
           echo-message:
           message-tags:
           monitor:
@@ -830,6 +835,9 @@
           typing-client-tag:
         SASL:
           - plain
+      partial:
+        stable:
+          extended-monitor: "draft cap"
 
 - name: Bouncers
   software:
@@ -980,7 +988,6 @@
           chathistory:
           chghost:
           event-playback:
-          extended-monitor:
           echo-message:
           extended-join:
           invite-notify:
@@ -999,6 +1006,7 @@
           plain:
       partial:
         stable:
+          extended-monitor: "draft cap"
           websockets: text only
     - name: soju (as Client)
       # ref: https://git.sr.ht/~emersion/soju/tree/master/upstream.go#L23
@@ -1015,7 +1023,6 @@
           cap-notify:
           chghost:
           echo-message:
-          extended-monitor:
           extended-join:
           invite-notify:
           labeled-response:
@@ -1031,6 +1038,9 @@
         SASL:
           external:
           plain:
+      partial:
+        stable:
+          extended-monitor: "draft cap"
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/search?q=OnServerCapAvailable+extension%3Acpp
       #      mSupportedCaps in https://github.com/znc/znc/blob/99687b0f2489826d35d59e662aebc9ec6cb34996/src/IRCSock.cpp

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -500,6 +500,7 @@
           chghost:
           echo-message:
           extended-join:
+          extended-monitor:
           invite-notify:
           message-tags:
           monitor:
@@ -520,9 +521,6 @@
         SASL:
           - plain
           - scram-sha-256
-      partial:
-        stable:
-          extended-monitor: "draft cap"
     - name: Kiwi IRC
       # ref: https://github.com/kiwiirc/kiwiirc
       #      https://github.com/kiwiirc/irc-framework/blob/v4.10.0/docs/ircv3.md
@@ -711,6 +709,7 @@
           chghost:
           echo-message:
           extended-join:
+          extended-monitor:
           invite-notify:
           labeled-response:
           message-tags:
@@ -729,9 +728,6 @@
         SASL:
           - plain
           - scram-sha-256
-      partial:
-        stable:
-          extended-monitor: "draft cap"
     - name: LimeChat
       # ref: https://github.com/psychs/limechat/blob/2.42/Classes/IRC/IRCClient.m#L3681
       link: http://limechat.net/iphone/

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -468,7 +468,7 @@
           chathistory:
           echo-message:
           extended-join:
-          extended-monitor: Gamja
+          extended-monitor: Git
           invite-notify:
           labeled-response:
           message-tags:

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -468,6 +468,7 @@
           chathistory:
           echo-message:
           extended-join:
+          extended-monitor: Gamja
           invite-notify:
           labeled-response:
           message-tags:
@@ -482,9 +483,6 @@
           whox:
         SASL:
           - plain
-      partial:
-        stable:
-          extended-monitor: "draft cap"
     - name: IRCCloud
       # maintainer: jwheare
       link: https://www.irccloud.com
@@ -823,6 +821,7 @@
           cap-notify:
           chathistory:
           echo-message:
+          extended-monitor: Git
           message-tags:
           monitor:
           multi-prefix:
@@ -835,9 +834,6 @@
           typing-client-tag:
         SASL:
           - plain
-      partial:
-        stable:
-          extended-monitor: "draft cap"
 
 - name: Bouncers
   software:
@@ -990,6 +986,7 @@
           event-playback:
           echo-message:
           extended-join:
+          extended-monitor: Git
           invite-notify:
           message-tags:
           monitor:
@@ -1006,7 +1003,6 @@
           plain:
       partial:
         stable:
-          extended-monitor: "draft cap"
           websockets: text only
     - name: soju (as Client)
       # ref: https://git.sr.ht/~emersion/soju/tree/master/upstream.go#L23
@@ -1024,6 +1020,7 @@
           chghost:
           echo-message:
           extended-join:
+          extended-monitor: Git
           invite-notify:
           labeled-response:
           message-tags:
@@ -1038,9 +1035,6 @@
         SASL:
           external:
           plain:
-      partial:
-        stable:
-          extended-monitor: "draft cap"
     - name: ZNC (as Server)
       # ref: https://github.com/znc/znc/search?q=OnServerCapAvailable+extension%3Acpp
       #      mSupportedCaps in https://github.com/znc/znc/blob/99687b0f2489826d35d59e662aebc9ec6cb34996/src/IRCSock.cpp

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -225,6 +225,7 @@
           chathistory:
           echo-message:
           extended-join:
+          extended-monitor: Git
           invite-notify: 6.0+
           labeled-response:
           message-tags:
@@ -245,4 +246,3 @@
         stable:
           account-registration: "6.0+ add-on"
           bot-mode: Draft
-          extended-monitor: "Draft, 6.0+"

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -35,7 +35,6 @@
           chghost:
           echo-message:
           extended-join:
-          extended-monitor:
           invite-notify:
           labeled-response:
           message-tags:
@@ -57,6 +56,9 @@
       na:
         stable:
           starttls: supports sts
+      partial:
+        stable:
+          extended-monitor: Draft
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/
@@ -223,7 +225,6 @@
           cap-notify:
           chghost:
           chathistory:
-          extended-monitor: 6.0+
           echo-message:
           extended-join:
           invite-notify: 6.0+
@@ -246,3 +247,4 @@
         stable:
           account-registration: "6.0+ add-on"
           bot-mode: Draft
+          extended-monitor: "Draft, 6.0+"

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -35,6 +35,7 @@
           chghost:
           echo-message:
           extended-join:
+          extended-monitor: Git
           invite-notify:
           labeled-response:
           message-tags:
@@ -56,9 +57,6 @@
       na:
         stable:
           starttls: supports sts
-      partial:
-        stable:
-          extended-monitor: Draft
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -319,7 +319,7 @@ implementations.
 The [Monitor spec]({{site.baseurl}}/specs/extensions/monitor.html) details this
 command, the relevant `RPL_ISUPPORT` token and the commands used with it.
 
-The **work-in-progress** [Extended Monitor spec]({{site.baseurl}}/specs/extensions/extended-monitor.html)
+The [Extended Monitor spec]({{site.baseurl}}/specs/extensions/extended-monitor.html)
 builds upon the Monitor spec, and extends it to various events.
 
 


### PR DESCRIPTION
Waiting for implementations of a draft spec to switch to the unprefixed cap:

* [x] Ergo https://github.com/ergochat/ergo/pull/2006
* [x] Gamja
* [x] Goguma
* [x] IRCCloud
* [x] Soju
* [x] UnrealIRCd https://github.com/unrealircd/unrealircd/pull/229

(if some are late, I'll update the support table to mention they only have the draft cap)