### PR TITLE
sw_clients: swirc: added sasl mechanism 'external'

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -403,6 +403,7 @@
           sasl-3.1:
           server-time:
         SASL:
+          - external
           - plain
           - scram-sha-256
     - name: Textual


### PR DESCRIPTION
Starting from Swirc v3.3.9 the SASL auth mechanism EXTERNAL has been added.
