### PR TITLE
Bump specs

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -151,6 +151,12 @@ stable:
       link: /specs/extensions/setname.html
       caps:
         - setname
+    standard-replies:
+      name: standard-replies
+      description: standard-replies
+      link: /specs/extensions/standard-replies.html
+      caps:
+        - standard-replies
     starttls:
       name: starttls
       description: tls Extension (STARTTLS)

--- a/_data/registry.yml
+++ b/_data/registry.yml
@@ -211,6 +211,10 @@
       specs:
         - setname
       description: Lets clients change their realname after connecting to the server.
+    - name: standard-replies
+      specs:
+        - standard-replies
+      description: Allows servers to use standard replies more broadly
     - name: tls
       specs:
         - starttls
@@ -388,6 +392,9 @@
       specs:
         - monitor
       description: Indicates the server supports the MONITOR command.
+    - name: MSGREFTYPES
+      specs:
+        - chathistory
     - name: UTF8ONLY
       specs:
         - utf8only

--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -166,6 +166,7 @@
           sasl-3.2:
           server-time:
           setname: 2.16
+          standard-replies: Git
           userhost-in-names:
           utf8only: 2.16
           whox:
@@ -371,6 +372,7 @@
           sasl-3.2:
           server-time:
           setname:
+          standard-replies: Git
           typing-client-tag:
           whox:
         SASL:
@@ -522,6 +524,7 @@
           sasl-3.2:
           server-time:
           setname:
+          standard-replies: Git
           sts:
           userhost-in-names:
           whox:
@@ -1181,6 +1184,7 @@
           server-time:
           setname:
           sts:
+          standard-replies: Git
           starttls:
           userhost-in-names:
           utf8only:

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -47,6 +47,7 @@
           sasl-3.1:
           sasl-3.2:
           server-time:
+          standard-replies: Git
           setname:
           userhost-in-names:
           utf8only:
@@ -132,6 +133,7 @@
           sasl-3.2:
           server-time:
           setname:
+          standard-replies: Git
           starttls:
           sts:
           userhost-in-names:


### PR DESCRIPTION
Includes the following commits:

* fc9e27796f00f053c17469fb5c5fe87f92f9e6cd chathistory: Add MSGREFTYPES ISUPPORT token (#510)
* f5fc907b99b60691c98423d7606d21d61fe05163 Add a capability for sending arbitrary standard replies. (#506)
* 0511d5645e93ec21cb2d9c4f9efec026698b9250 extensions/webirc.md: correct some typos (#512)
* 6c7683e4dd24593cc7f589f778e0c1c5997a2f24 UTF8ONLY: remove suggestion to disconnect the client (#502)

Standard replies are not an addition and they are already linked from _irc/index.md; we only forgot to add them to `irc_versions.yml` before.

Based on https://github.com/ircv3/ircv3-specifications/pull/506#issuecomment-1367978049 (Marking this PR as draft as Insp and Limnoria don't yet have it in Git)