### PR TITLE
Add iOS support to Goguma

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -841,6 +841,7 @@
       os:
         - android
         - linux
+        - ios
       support:
         stable:
           away-notify:


### PR DESCRIPTION
Goguma is now available on the Apple App Store.