### PR TITLE
Update specs

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -274,6 +274,22 @@ stable:
       caps:
         - draft/read-marker
 
+    no-implicit-names:
+      name: draft/no-implicit-names
+      description: Disable implicit NAMES responses DRAFT
+      link: /specs/extensions/no-implicit-names.html
+      draft: true
+      caps:
+        - draft/no-implicit-names
+
+    pre-away:
+      name: draft/pre-away
+      description: AWAY during connection registration
+      link: /specs/extensions/pre-away.html
+      draft: true
+      caps:
+        - draft/pre-away
+
 proposed:
   name: Proposed Pull Requests
   specs:

--- a/_data/registry.yml
+++ b/_data/registry.yml
@@ -194,6 +194,14 @@
       specs:
         - multiline
       description: Allows clients and servers to use send messages that can exceed the usual byte length limit and that can contain line breaks.
+    - name: no-implicit-names
+      specs:
+        - no-implicit-names
+      description: Disables implicit NAMES responses on JOIN.
+    - name: pre-away
+      specs:
+        - pre-away
+      description: Allows clients to send AWAY commands during connection registration.
     - name: read-marker
       specs:
         - read-marker

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -184,13 +184,13 @@ The `channel-rename` extension adds a new command sent by clients and servers th
 The **work-in-progress** [`channel-rename` spec]({{site.baseurl}}/specs/extensions/channel-rename.html) describes how to use the `RENAME` command to achieve this.
 
 
-## [Chathistory]({{site.baseurl}}/specs/extensions/chathistory.html)
+## Persistence
 
-The `chathistory` extension standardizes a mechanism for clients to request message history from servers or bouncers.
-
-The **work-in-progress** [`chathistory` spec]({{site.baseurl}}/specs/extensions/chathistory.html) describes the syntax and semantics of the new `CHATHISTORY` command.
+The **work-in-progress** [`chathistory` spec]({{site.baseurl}}/specs/extensions/chathistory.html) describes the syntax and semantics of the new `CHATHISTORY` command, which standardizes a mechanism for clients to request message history from servers or bouncers.
 
 The **work-in-progress** [`read-marker` spec]({{site.baseurl}}/specs/extensions/read-marker.html) adds a new command to synchronize read markers between several clients of the same user.
+
+The **work-in-progress** [`pre-away` spec]({{site.baseurl}}/specs/extensions/pre-away.html) allows clients to send `AWAY` commands during connection registration.
 
 
 ## Changing User Properties
@@ -278,10 +278,14 @@ This allows clients to more easily see the
 user/hostnames of other clients when joining channels. This allows clients to
 better track info and automate client features more easily.
 
-Finally, the [`WHOX` spec]({{site.baseurl}}/specs/extensions/whox.html)
+The [`WHOX` spec]({{site.baseurl}}/specs/extensions/whox.html)
 describes how the `WHO` message and its replies changes with this capability active
 to allow clients to request more data, and how clients should interpret these changes.
 
+The **work-in-progress** [`no-implicit-names` spec]({{site.baseurl}}/specs/extensions/no-implicit-names.html)
+allows clients to disable the implicit `NAMES` responses sent after `JOIN` in
+case they don't always need that information for all channels. Clients can
+still query that information as needed via the `NAMES` or `WHO` command.
 
 
 ## [Message IDs]({{site.baseurl}}/specs/extensions/message-ids.html)


### PR DESCRIPTION
Includes the following commits:

f576e45d7a5d Add draft/no-implicit-names (#527)
21fbe434df03 capability-negotiation: Mention trailing space in capability lists (#530) bdf27508bf7f away-notify: Clarify away notifications should not be echoed (#531) fd2030299947 multiline: Clarify what counts toward max-bytes (#517) 6f3eca027ff3 add pre-away extension (#514)
838ef3973850 sasl-3.1: add example with split client response (#521) 515fdabe0eba capability-negotiation: clarify CAP names cannot start with hyphen (#519)