### PR TITLE
Update glirc support table

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -120,30 +120,37 @@
           whox:
         SASL:
           - plain
-    - name: Glirc
-      # ref: https://github.com/glguy/irc-core/blob/v2/src/Client/State/Network.hs#L766
+    - name: glirc
+      # ref: selectCaps in https://github.com/glguy/irc-core/blob/v2/src/Client/State/Network.hs
       link: https://hackage.haskell.org/package/glirc
       support:
         stable:
-          account-notify:
-          account-tag:
-          away-notify:
+          account-notify: 2.28+
+          account-tag: 2.39+
+          away-notify: 2.40+
           batch:
           cap-notify:
           cap-3.1:
-          cap-3.2:
-          chghost:
-          extended-join:
+          cap-3.2: 2.30+
+          chghost: 2.30+
+          extended-join: 2.28+
+          extended-monitor: 2.41+
+          invite-notify: 2.41+
+          message-tags: 2.41+
           multi-prefix:
+          monitor: 2.36+
           sasl-3.1:
-          server-time:
-          sts:
-          userhost-in-names:
+          server-time: 2.28+
+          sts: 2.30+
+          userhost-in-names: 2.30+
+          whox: 2.40+
         SASL:
           - plain
           - external
           - scram-sha-1
           - scram-sha-256
+          - ecdsa-nist256p-challenge
+          - ecdh-x25519-challenge
     - name: Halloy
       # ref: https://halloy.squidowl.org/index.html
       link: https://halloy.squidowl.org


### PR DESCRIPTION
Hi, collaborator on [glirc](https://github.com/glguy/irc-core) here. With the 2.41 release [right around the corner](https://github.com/glguy/irc-core/commit/82a318aadbdf9a6e7c46131845da2eebbad7905f), I figured now would be a good time to PR an update glirc's row in the client support table. This commit also indicates when support for various IRCv3 features was added for every version of glirc newer than the oldest packaged version (2.24 on Ubuntu 18.04), as well as adds two missing SASL mechanisms.