### PR TITLE
halloy 2024.10 now supports: chghost, account-notify and extended-join

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -156,10 +156,13 @@
         stable:
           away-notify:
           batch:
+          account-notify: 2024.10+
           cap-3.1:
           cap-3.2: 2024.7+
           cap-notify: 2024.7+
+          chghost: 2024.10+
           echo-message:
+          extended-join: 2024.10+
           invite-notify:
           labeled-response:
           message-tags: 2024.7+


### PR DESCRIPTION
Added halloy supporting chghost, account-notify and extended-join.

see: https://github.com/squidowl/halloy/releases/tag/2024.10