### PR TITLE
Fix broken RFC4616 (SASL PLAIN) links

### DIFF
--- a/_data/doc_sasl.yml
+++ b/_data/doc_sasl.yml
@@ -10,7 +10,7 @@ SASL:
       name: PLAIN
       description: PLAIN SASL mechanism
       required: true
-      ext_link: https://tools.ietf.org/search/rfc4616
+      ext_link: https://tools.ietf.org/html/rfc4616
     scram-sha-256:
       name: SCRAM-SHA-256
       description: SASL SCRAM-SHA-256 mechanism
@@ -20,4 +20,4 @@ SASL:
       name: OAUTHBEARER
       description: OAUTHBEARER SASL mechanism
       required: true
-      ext_link: https://www.rfc-editor.org/rfc/rfc7628
+      ext_link: https://tools.ietf.org/html/rfc7628

--- a/_irc/index.md
+++ b/_irc/index.md
@@ -102,7 +102,7 @@ what to do if the authentication layer is disconnected or reconnected.
 IRC SASL authentication primarily uses the same mechanisms as SASL in other
 protocols. Most commonly:
 
-* [PLAIN](https://tools.ietf.org/search/rfc4616) as defined by RFC 4616
+* [PLAIN](https://tools.ietf.org/html/rfc4616) as defined by RFC 4616
 * [EXTERNAL](https://tools.ietf.org/html/rfc4422#appendix-A) as defined by RFC 4422
 * [SCRAM-SHA-256](https://tools.ietf.org/html/rfc7677) as defined by RFC 7677
 

--- a/docs/sasl-mechs.md
+++ b/docs/sasl-mechs.md
@@ -7,7 +7,7 @@ page-header: >
 ---
 IRC SASL authentication primarily uses the same mechanisms as SASL in other protocols. Most commonly:
 
-* [PLAIN](https://tools.ietf.org/search/rfc4616) as defined by RFC 4616
+* [PLAIN](https://tools.ietf.org/html/rfc4616) as defined by RFC 4616
 * [EXTERNAL](https://tools.ietf.org/html/rfc4422#appendix-A) as defined by RFC 4422
 * [SCRAM-SHA-256](https://tools.ietf.org/html/rfc7677) as defined by RFC 7677
 


### PR DESCRIPTION
The /search/rfc* links now 404.
Also changes the OAUTHBEARER link go to the IETF HTML viewer like the others.