### PR TITLE
Update ircv3 extensions after Halloy 2025.1

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -169,9 +169,11 @@
           multi-prefix: 2024.7+
           extended-monitor: 2024.11+
           monitor: 2024.11+
-          chathistory: Git
+          chathistory: 2025.1+
           sasl-3.1:
           server-time:
+          setname: 2025.1+
+          standard-replies: 2025.1+
           userhost-in-names:
           utf8only: 2024.7+
           whox: 2024.7+


### PR DESCRIPTION
Updated IRCv3 extensions after our 2025.1 release of Halloy.