### PR TITLE
Halloy: add neglected extensions from 2024.12.

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -169,7 +169,9 @@
           multi-prefix: 2024.7+
           extended-monitor: 2024.11+
           monitor: 2024.11+
+          msgid: 2024.12+
           chathistory: 2025.1+
+          read-marker: 2024.12+
           sasl-3.1:
           server-time:
           setname: 2025.1+


### PR DESCRIPTION
Some IRCv3 extensions added in version 2024.12 never made it into the table.