### PR TITLE
Add Metadata to Ergo

### DIFF
--- a/_data/irc_versions.yml
+++ b/_data/irc_versions.yml
@@ -109,6 +109,8 @@ stable:
       description: Metadata
       link: /specs/extensions/metadata.html
       draft: true
+      caps:
+        - draft/metadata-2
     monitor:
       name: Monitor
       description: Monitor

--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -24,6 +24,7 @@
           labeled-response:
           message-redaction:
           message-tags:
+          metadata: Git
           monitor:
           msgid:
           multi-prefix:


### PR DESCRIPTION
Nice and simple:
![image](https://github.com/user-attachments/assets/c677e92b-5b66-464e-b70c-b6f668c4dd4f)

Soju already has support marked, and this doesn't affect how it's listed there.