### PR TITLE
Add Circe to desktop clients

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -94,6 +94,17 @@
       na:
         stable:
           sts: TLS-only
+    - name: Circe
+      # ref: https://github.com/emacs-circe/circe/wiki/Features#ircv3-support
+      link: https://github.com/emacs-circe/circe
+      support:
+        stable:
+          cap-3.1:
+          extended-join:
+          sasl-3.1:
+        SASL:
+          - external
+          - plain
     - name: Colloquy
       # ref: handleCapWithParameters() in https://github.com/colloquy/colloquy/blob/main/Chat%20Core/MVIRCChatConnection.m
       # https://github.com/colloquy/colloquy/blob/4c47cfbaf686e1ac18937e5727b240d7df60d06d/Chat%20Core/MVIRCChatConnection.m#L2036


### PR DESCRIPTION
I currently maintain Circe and noticed it's possible to track IRCv3 support by contributing a PR.