### PR TITLE
su_networks: add hackint.org

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -481,3 +481,4 @@
           echo-message:
           message-tags:
           server-time:
+          whox:


### PR DESCRIPTION
closes https://github.com/ircv3/ircv3.github.io/issues/419

capabilities gathered using `printf "CAP LS 302\r\nQUIT\r\n" | openssl s_client -connect irc.hackint.org:6697 -servername irc.hackint.org -quiet`

> `:palermo.hackint.org CAP * LS :account-notify away-notify chghost extended-join multi-prefix sasl=PLAIN,AUTHCOOKIE,EXTERNAL,ECDSA-NIST256P-CHALLENGE tls userhost-in-names account-tag cap-notify echo-message message-tags server-time`