### PR TITLE
Biboumi bridge

### DIFF
--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -5,11 +5,13 @@
       link: https://biboumi.codeberg.page/
       support:
         stable:
-          cap-3.1:
-          multi-prefix:
+          multi-prefix: 3.0+
           webirc:
         SASL:
-            - plain
+          plain: 9.0+
+      partial:
+        stable:
+          cap-3.1: "req cap"
     - name: BitlBee
       # ref: https://github.com/bitlbee/bitlbee/blob/3.6/irc_cap.c#L39
       link: https://bitlbee.org/

--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -6,6 +6,7 @@
       support:
         stable:
           multi-prefix: 3.0+
+          sasl-3.1: 9.0+
           webirc:
         SASL:
           plain: 9.0+

--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -1,13 +1,12 @@
 - name: Bridges
   software:
     - name: Biboumi
-      # ref: TODO
       link: https://biboumi.codeberg.page/
       support:
         stable:
           multi-prefix: 3.0+
           sasl-3.1: 9.0+
-          webirc:
+          webirc: 3.0+
         SASL:
           plain: 9.0+
       partial:

--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -5,13 +5,11 @@
       support:
         stable:
           multi-prefix: 3.0+
+          cap-3.1: 3.0+
           sasl-3.1: 9.0+
           webirc: 3.0+
         SASL:
           plain: 9.0+
-      partial:
-        stable:
-          cap-3.1: "req cap"
     - name: BitlBee
       # ref: https://github.com/bitlbee/bitlbee/blob/3.6/irc_cap.c#L39
       link: https://bitlbee.org/

--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -1,5 +1,26 @@
 - name: Bridges
   software:
+    - name: Biboumi
+      # ref: TODO
+      link: https://biboumi.codeberg.page/
+      support:
+        stable:
+          batch: 10+
+          cap-3.1:
+          cap-3.2: 10+
+          echo-message: 10+
+          labeled-response: 10+
+          message-tags: 10+
+          multiline: 10+
+          multi-prefix:
+          sasl-3.1: 10+
+        SASL:
+            - plain
+      na:
+        stable:
+          react-client-tag:
+          reply-client-tag:
+          webirc:
     - name: BitlBee
       # ref: https://github.com/bitlbee/bitlbee/blob/3.6/irc_cap.c#L39
       link: https://bitlbee.org/

--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -5,22 +5,11 @@
       link: https://biboumi.codeberg.page/
       support:
         stable:
-          batch: 10+
           cap-3.1:
-          cap-3.2: 10+
-          echo-message: 10+
-          labeled-response: 10+
-          message-tags: 10+
-          multiline: 10+
           multi-prefix:
-          sasl-3.1: 10+
+          webirc:
         SASL:
             - plain
-      na:
-        stable:
-          react-client-tag:
-          reply-client-tag:
-          webirc:
     - name: BitlBee
       # ref: https://github.com/bitlbee/bitlbee/blob/3.6/irc_cap.c#L39
       link: https://bitlbee.org/


### PR DESCRIPTION
# Biboumi, the XMPP->IRC bridge

I request a pull to include Biboumi, a bridge from XMPP servers to IRC networks.

More exactly Biboumi is a *puppeteering* gateway. It basically acts as an IRC client.

To know more about Biboumi you can visit the website <https://biboumi.codeberg.page/>.

To exchange about the project `biboumi@muc.poez.io` is the privileged XMPP room.