### PR TITLE
su_networks: Add missing Libera.Chat features

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -320,6 +320,7 @@
       link: https://libera.chat
       support:
         stable:
+          account-extban:
           account-notify:
           account-tag:
           away-notify:
@@ -337,6 +338,7 @@
           sasl-3.1:
           sasl-3.2:
           server-time:
+          whox:
       partial:
         stable:
           message-tags: Filtered client tags


### PR DESCRIPTION
Marks `account-extban` and `whox` as supported by Libera.Chat.