### PR TITLE
Add HybridIRC support to IRCv3 networks.yml

### DIFF
--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -263,6 +263,33 @@
           server-time:
           userhost-in-names:
           whox:
+    - name: HybridIRC
+      ircd-ver: InspIRCd-4
+      net-address:
+        link: ircs://irc.hybridirc.com:6697
+        display: irc.hybridirc.com
+      link: https://www.hybridirc.com/
+      support:
+        stable:
+          account-notify:
+          account-tag:
+          away-notify:
+          batch:
+          cap-notify:
+          chghost:
+          echo-message:
+          extended-join:
+          extended-monitor:
+          invite-notify:
+          labeled-response:
+          message-tags:
+          multi-prefix:
+          sasl-3.1:
+          sasl-3.2:
+          server-time:
+          setname:
+          standard-replies:
+          userhost-in-names:
     - name: IRC4Fun
       ircd-ver: InspIRCd-3
       net-address:

--- a/_data/su_networks.yml
+++ b/_data/su_networks.yml
@@ -275,6 +275,8 @@
           account-tag:
           away-notify:
           batch:
+          cap-3.1:
+          cap-3.2:
           cap-notify:
           chghost:
           echo-message:
@@ -284,12 +286,15 @@
           labeled-response:
           message-tags:
           multi-prefix:
+          monitor:
+          msgid:
           sasl-3.1:
           sasl-3.2:
           server-time:
           setname:
           standard-replies:
           userhost-in-names:
+          whox:
     - name: IRC4Fun
       ircd-ver: InspIRCd-3
       net-address:


### PR DESCRIPTION
Added support information for HybridIRC network to the IRCv3 networks.yml file.

This includes the following stable IRCv3 capabilities:
- account-notify
- account-tag
- away-notify
- batch
- cap-notify
- chghost
- echo-message
- extended-join
- extended-monitor
- invite-notify
- labeled-response
- message-tags
- multi-prefix
- sasl-3.1
- sasl-3.2
- server-time
- setname
- standard-replies
- userhost-in-names

Capabilities were verified via CAP LS command on the main IRC server.