### PR TITLE
sw_bridges.yml: add j2i

### DIFF
--- a/_data/sw_bridges.yml
+++ b/_data/sw_bridges.yml
@@ -49,6 +49,26 @@
           channel-context-client-tag:
           chghost:
           userhost-in-names:
+    - name: j2i
+      # ref: https://foundry.fsky.io/telepath/j2i/src/branch/main/src/j2i/irc/client.py#L508-L557
+      link: https://telepath.im/projects/j2i/
+      support:
+        stable:
+          cap-3.1:
+          cap-3.2:
+          away-notify:
+          batch:
+          echo-message:
+          message-tags:
+          msgid:
+          multiline:
+          bot-mode:
+          sasl-3.1:
+          react-client-tag:
+          reply-client-tag:
+          typing-client-tag:
+        SASL:
+          - plain
     - name: matrix-appservice-irc
       # ref: https://github.com/matrix-org/node-irc/blob/1.5.0/src/irc.ts#L339-L352
       #      https://github.com/matrix-org/node-irc/blob/1.5.0/src/irc.ts#L1199


### PR DESCRIPTION
Added [j2i](https://telepath.im/projects/j2i/) to the bridge list. j2i is a pretty new XMPP <-> IRC plumbing bridge with IRCv3 features.