### PR TITLE
Add Halloy as a IRCv3 Specifications Consumer

### DIFF
--- a/_data/consumers.yml
+++ b/_data/consumers.yml
@@ -9,3 +9,6 @@
 
 - name: The Lounge
   url: https://thelounge.chat/
+
+- name: Halloy
+  url: https://halloy.chat/


### PR DESCRIPTION
Appends Halloy to the list of IRCv3 observers/implementers (the lists on https://ircv3.net/participation did not appear to be sorted, so last on the list seemed most appropriate).  Hopefully this is appropriate as we have been observing and implementing IRCv3 specifications (and expect to continue doing so).