### PR TITLE
Add Mango to the client list

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -331,6 +331,39 @@
         # server-time:  # only supports znc's vendor prefixed version
         SASL:
           - plain
+    - name: Mango
+      link: https://mangoirc.chat
+      support:
+        stable:
+          account-notify:
+          account-tag:
+          away-notify:
+          batch:
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          chathistory:
+          chghost:
+          echo-message:
+          extended-join:
+          labeled-response:
+          message-tags:
+          monitor:
+          msgid:
+          multi-prefix:
+          react-client-tag:
+          read-marker:
+          reply-client-tag:
+          sasl-3.1:
+          sasl-3.2:
+          server-time:
+          setname:
+          sts:
+          tls:
+          typing-client-tag:
+          userhost-in-names:
+        SASL:
+          - plain
     - name: mIRC
       # ref: https://www.mirc.com/news.html
       #      https://www.mirc.com/versions.txt
@@ -911,6 +944,41 @@
         stable:
           cap-3.1:
           sasl-3.1:
+        SASL:
+          - plain
+    - name: Mango
+      link: https://mangoirc.chat
+      os:
+        - ios
+      support:
+        stable:
+          account-notify:
+          account-tag:
+          away-notify:
+          batch:
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          chathistory:
+          chghost:
+          echo-message:
+          extended-join:
+          labeled-response:
+          message-tags:
+          monitor:
+          msgid:
+          multi-prefix:
+          react-client-tag:
+          read-marker:
+          reply-client-tag:
+          sasl-3.1:
+          sasl-3.2:
+          server-time:
+          setname:
+          sts:
+          tls:
+          typing-client-tag:
+          userhost-in-names:
         SASL:
           - plain
     - name: Palaver


### PR DESCRIPTION
[Mango](https://mangoirc.chat) is a modern, native IRC client for macOS and iOS/iPadOS, written from scratch in Swift + SwiftUI. This adds it to both the **Desktop Clients** and **Mobile Clients** sections.

### Supported IRCv3 capabilities

Both entries advertise the same negotiated capability set:

`account-notify`, `account-tag`, `away-notify`, `batch`, `cap-3.1`, `cap-3.2` (CAP LS 302), `cap-notify`, `chathistory` (`draft/chathistory`), `chghost`, `echo-message`, `extended-join`, `labeled-response`, `message-tags`, `monitor`, `msgid`, `multi-prefix`, `react-client-tag` (`+draft/react`), `read-marker` (`draft/read-marker`), `reply-client-tag` (`+draft/reply`), `sasl-3.1`/`sasl-3.2`, `server-time`, `setname`, `sts`, `tls`, `typing-client-tag` (`+typing`), `userhost-in-names`.

SASL: `PLAIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)