### PR TITLE
Add ferrixd to the server list

### DIFF
--- a/_data/sw_servers.yml
+++ b/_data/sw_servers.yml
@@ -61,6 +61,56 @@
         stable:
           no-implicit-names: "draft cap"
 
+    - name: ferrixd
+      # maintainer: JosunLP
+      link: https://josunlp.github.io/ferrixd/
+      support:
+        stable:
+          account-extban:
+          account-notify:
+          account-registration:
+          account-tag:
+          away-notify:
+          batch:
+          bot-mode:
+          cap-3.1:
+          cap-3.2:
+          cap-notify:
+          channel-rename:
+          chathistory:
+          chghost:
+          echo-message:
+          extended-isupport:
+          extended-join:
+          extended-monitor:
+          invite-notify:
+          labeled-response:
+          message-redaction:
+          message-tags:
+          metadata:
+          monitor:
+          msgid:
+          multi-prefix:
+          multiline:
+          network-icon:
+          no-implicit-names:
+          pre-away:
+          read-marker:
+          sasl-3.1:
+          sasl-3.2:
+          server-time:
+          setname:
+          standard-replies:
+          sts:
+          userhost-in-names:
+          utf8only:
+          webirc:
+          websockets:
+          whox:
+        na:
+          stable:
+            starttls: supports sts
+
     - name: IRCCloud Teams
       # maintainer: jwheare
       link: https://blog.irccloud.com/private-teams-servers/


### PR DESCRIPTION
Adds **ferrixd** to the servers listing.

ferrixd ("the Ferrous IRC Daemon") is a from-scratch IRC server written in Rust — memory-safe (zero `unsafe`, forbidden workspace-wide), TLS-first, federated over mutual TLS, and IRCv3-complete. Submitted by the server author.

- Docs / homepage: https://josunlp.github.io/ferrixd/
- Source: https://github.com/josunlp/ferrixd
- License: MIT OR Apache-2.0 · current release: v1.2.0

SASL mechanisms: `PLAIN`, `EXTERNAL`, `SCRAM-SHA-256`.

The listed capabilities reflect what is implemented and released in v1.1.0, verified against the source (`crates/ferrixd/src/cap.rs` and the ISUPPORT emitted at runtime). `starttls` is marked N/A because ferrixd is TLS-first and enforces STS, matching how other TLS-first servers are listed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
