### PR TITLE
Allow marking software as using AI in their development.

### DIFF
--- a/_data/sw_clients.yml
+++ b/_data/sw_clients.yml
@@ -780,6 +780,7 @@
       #ref https://github.com/ObsidianIRC/ObsidianIRC/blob/609af22ee1c30087e8d9125951f749501398617d/src/store/index.ts#L1035-L1083 (Typing)
       #ref https://github.com/ObsidianIRC/ObsidianIRC/blob/609af22ee1c30087e8d9125951f749501398617d/src/lib/ircClient.ts#L450 (SASL)
       link: https://github.com/ObsidianIRC/ObsidianIRC
+      ai: true
       support:
         stable:
           account-notify:

--- a/_data/validation/sw_list.types.yaml
+++ b/_data/validation/sw_list.types.yaml
@@ -13,6 +13,9 @@ software:
           type: string
         link:
           type: string
+        ai:
+          type: boolean
+          required: false
         ircd-ver:
           type: string
           required: false

--- a/_includes/support_list.html
+++ b/_includes/support_list.html
@@ -70,8 +70,11 @@
                 {% if sw.note %}
                     <div class="sw-note">{{ sw.note | markdownify }}</div>
                 {% endif %}
-                {% if sw.os %}
+                {% if sw.os or sw.ai %}
                     <div class="os-support">
+                    {% if sw.ai %}
+                         <i title="Development assisted using AI" class="fa-solid fa-robot os-support-ai"></i>
+                    {% endif %}
                     {% for name in sw.os %}
                         {% if site.data.os[name] %}
                             <i title="{{ site.data.os[name]["name"] }}" class="{{ site.data.os[name]["icon"] }} os-support-{{ name | slugify }}"></i>

--- a/_includes/support_list.html
+++ b/_includes/support_list.html
@@ -73,7 +73,7 @@
                 {% if sw.os or sw.ai %}
                     <div class="os-support">
                     {% if sw.ai %}
-                         <i title="Development assisted using AI" class="fa-solid fa-robot os-support-ai"></i>
+                         <i title="Development assisted using AI" class="fa-solid fa-robot ai-assisted"></i>
                     {% endif %}
                     {% for name in sw.os %}
                         {% if site.data.os[name] %}

--- a/css/partials/_swtable.scss
+++ b/css/partials/_swtable.scss
@@ -332,7 +332,7 @@ tr.popup-above .support .hover-popup > div:after {
   color: #222;
 }
 .os-support-ai {
-  color: #8a2be2;
+  color: #bbb;
 }
 
 @media only screen and (max-width: 500px)  {

--- a/css/partials/_swtable.scss
+++ b/css/partials/_swtable.scss
@@ -331,6 +331,9 @@ tr.popup-above .support .hover-popup > div:after {
 .os-support-linux {
   color: #222;
 }
+.os-support-ai {
+  color: #8a2be2;
+}
 
 @media only screen and (max-width: 500px)  {
   .support-table {

--- a/css/partials/_swtable.scss
+++ b/css/partials/_swtable.scss
@@ -331,7 +331,7 @@ tr.popup-above .support .hover-popup > div:after {
 .os-support-linux {
   color: #222;
 }
-.os-support-ai {
+.ai-assisted {
   color: #bbb;
 }
 


### PR DESCRIPTION
Given the recent debates over AI use I think its reasonable to propose marking software so people reading the software lists can make a fully informed choice.

I've marked ObsidianIRC as I know for sure that is AI assisted but if there is any software I have missed please notify me and I will mark them.

We should probably also have some kind of rule for what actually consists AI assisted. I'd personally lean towards marking anything substantially AI assisted to avoid potential witch hunts about whether minor patches are AI or not.

---

This piggybacks off the existing support for labelling OS support. I can change this if necessary but it felt like I would just be duplicating code to do anything else.